### PR TITLE
fix: empty config throws null reference exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All processes within the deployed solution(s) are activated by default after the
 </templateconfig>
 ```
 
-If your deployment is running as an application user then you may face [some issues](https://github.com/MicrosoftDocs/power-automate-docs/issues/216) if your solution contains flows. If you wish to continue deploying as an application user, you can pass the `LicensedUsername` and `LicensedPassword` runtime settings to the Package Deployer (or set the `PACKAGEDEPLOYER_SETTINGS_LICENSEDUSERNAME and `PACKAGEDEPLOYER_SETTINGS_LICENSEDPASSWORD` environment variables) and these credentials will be used for flow activation.
+If your deployment is running as an application user then you may face [some issues](https://github.com/MicrosoftDocs/power-automate-docs/issues/216) if your solution contains flows. If you wish to continue deploying as an application user, you can pass the `LicensedUsername` and `LicensedPassword` runtime settings to the Package Deployer (or set the `PACKAGEDEPLOYER_SETTINGS_LICENSEDUSERNAME` and `PACKAGEDEPLOYER_SETTINGS_LICENSEDPASSWORD` environment variables) and these credentials will be used for flow activation.
 
 > You can also activate or deactivate processes that are not in your package by setting the `external` attribute to `true` on a `<process>` element. Be careful when doing this - deploying your package may introduce side-effects to an environment that make it incompatible with other solutions.
 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -43,7 +43,7 @@
         }
 
         /// <inheritdoc/>
-        public IEnumerable<Guid> RetieveSolutionComponentsObjectIds(string solutionName, int componentType)
+        public IEnumerable<Guid> RetrieveSolutionComponentObjectIds(string solutionName, int componentType)
         {
             var queryExpression = new QueryExpression(Constants.SolutionComponent.LogicalName)
             {
@@ -184,7 +184,12 @@
                 return new EntityCollection();
             }
 
-            var objectIds = solutions.SelectMany(s => this.RetieveSolutionComponentsObjectIds(s, solutionComponentType));
+            var objectIds = solutions.SelectMany(s => this.RetrieveSolutionComponentObjectIds(s, solutionComponentType));
+            if (!objectIds.Any())
+            {
+                return new EntityCollection();
+            }
+
             var entityQuery = new QueryExpression(componentLogicalName)
             {
                 ColumnSet = columnSet ?? new ColumnSet(false),

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -61,7 +61,7 @@
         /// <param name="solutionName">The unique name of the solution.</param>
         /// <param name="componentType">The type of the components.</param>
         /// <returns>A collection of object IDs.</returns>
-        IEnumerable<Guid> RetieveSolutionComponentsObjectIds(string solutionName, int componentType);
+        IEnumerable<Guid> RetrieveSolutionComponentObjectIds(string solutionName, int componentType);
 
         /// <summary>
         /// Retrieve deployed component records for the given solution(s) and component type.

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Config/ConfigDataStorage.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Config/ConfigDataStorage.cs
@@ -9,6 +9,14 @@
     public class ConfigDataStorage
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigDataStorage"/> class.
+        /// </summary>
+        public ConfigDataStorage()
+        {
+            this.TemplateConfig = new TemplateConfig();
+        }
+
+        /// <summary>
         /// Gets or sets the configuration used by <see cref="PackageTemplateBase"/>.
         /// </summary>
         /// <value>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Config/TemplateConfig.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Config/TemplateConfig.cs
@@ -12,6 +12,18 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
     public class TemplateConfig
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateConfig"/> class.
+        /// </summary>
+        public TemplateConfig()
+        {
+            this.Processes = Array.Empty<ProcessConfig>();
+            this.SdkSteps = Array.Empty<SdkStepConfig>();
+            this.DocumentTemplates = Array.Empty<DocumentTemplateConfig>();
+            this.DataImports = Array.Empty<DataImportConfig>();
+            this.Slas = Array.Empty<SlaConfig>();
+        }
+
+        /// <summary>
         /// Gets or sets a collection of processes and their deployment configuration.
         /// </summary>
         /// <value>
@@ -19,7 +31,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// </value>
         [XmlArray("processes")]
         [XmlArrayItem("process")]
-        public ProcessConfig[] Processes { get; set; } = Array.Empty<ProcessConfig>();
+        public ProcessConfig[] Processes { get; set; }
 
         /// <summary>
         /// Gets processes configured to be inactive after deployment.
@@ -43,7 +55,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// </value>
         [XmlArray("sdksteps")]
         [XmlArrayItem("sdkstep")]
-        public SdkStepConfig[] SdkSteps { get; set; } = Array.Empty<SdkStepConfig>();
+        public SdkStepConfig[] SdkSteps { get; set; }
 
         /// <summary>
         /// Gets SDK steps configured to be inactive after deployment.
@@ -67,7 +79,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// </value>
         [XmlArray("documenttemplates")]
         [XmlArrayItem("documenttemplate")]
-        public DocumentTemplateConfig[] DocumentTemplates { get; set; } = Array.Empty<DocumentTemplateConfig>();
+        public DocumentTemplateConfig[] DocumentTemplates { get; set; }
 
         /// <summary>
         /// Gets or sets a list of data import configurations.
@@ -78,7 +90,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// </value>
         [XmlArray("dataimports")]
         [XmlArrayItem("dataimport")]
-        public DataImportConfig[] DataImports { get; set; } = Array.Empty<DataImportConfig>();
+        public DataImportConfig[] DataImports { get; set; }
 
         /// <summary>
         /// Gets a collection of data import configurations to run post-deployment.
@@ -102,7 +114,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// </value>
         [XmlArray("slas")]
         [XmlArrayItem("sla")]
-        public SlaConfig[] Slas { get; set; } = Array.Empty<SlaConfig>();
+        public SlaConfig[] Slas { get; set; }
 
         /// <summary>
         /// Gets SLAs configured to be set as default.
@@ -120,7 +132,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Config
         /// A value indicating whether to deactivate all SLAs before deployment and activate all SLAs after deployment.
         /// </value>
         [XmlAttribute("activatedeactivateslas")]
-        public bool ActivateDeactivateSLAs { get; set; } = true;
+        public bool ActivateDeactivateSLAs { get; set; }
 
         /// <summary>
         /// Load the template config from the specified path.

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -84,7 +84,7 @@
         {
             if (processes is null)
             {
-                throw new ArgumentNullException(nameof(processes));
+                return;
             }
 
             foreach (var deployedProcess in processes)

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
@@ -80,11 +80,11 @@
             this.SetStates(sdkSteps, componentsToDeactivate);
         }
 
-        private void SetStates(DataCollection<Entity> sdkSteps, IEnumerable<string> sdkStepsToDeactivate)
+        private void SetStates(IEnumerable<Entity> sdkSteps, IEnumerable<string> sdkStepsToDeactivate)
         {
             if (sdkSteps is null)
             {
-                throw new ArgumentNullException(nameof(sdkSteps));
+                return;
             }
 
             foreach (var deployedSdkStep in sdkSteps)

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.csproj
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.csproj
@@ -64,6 +64,9 @@
     <ProjectReference Include="..\..\src\Capgemini.PowerApps.PackageDeployerTemplate\Capgemini.PowerApps.PackageDeployerTemplate.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Resources\EmptyImportConfig.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resources\ImportConfig.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Resources/EmptyImportConfig.xml
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Resources/EmptyImportConfig.xml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0"?>
+<configdatastorage xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" installsampledata="false" waitforsampledatatoinstall="true" agentdesktopzipfile="" agentdesktopexename="" crmmigdataimportfile="">
+</configdatastorage>

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/TemplateConfigTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/TemplateConfigTests.cs
@@ -14,9 +14,15 @@
         }
 
         [Fact]
-        public void Load_TemplateConfigElementPresenet_TemplateConfigIsDeserialised()
+        public void Load_TemplateConfigElementPresent_TemplateConfigIsDeserialised()
         {
             this.config.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Load_TemplateConfigElementNotPresent_TemplateConfigIsDefaulted()
+        {
+            Load("EmptyImportConfig.xml").Should().NotBeNull();
         }
 
         [Fact]

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/TemplateConfigTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/TemplateConfigTests.cs
@@ -7,10 +7,12 @@
     public class TemplateConfigTests
     {
         private readonly TemplateConfig config;
+        private readonly TemplateConfig defaultConfig;
 
         public TemplateConfigTests()
         {
             this.config = Load("ImportConfig.xml");
+            this.defaultConfig = Load("EmptyImportConfig.xml");
         }
 
         [Fact]
@@ -22,7 +24,13 @@
         [Fact]
         public void Load_TemplateConfigElementNotPresent_TemplateConfigIsDefaulted()
         {
-            Load("EmptyImportConfig.xml").Should().NotBeNull();
+            this.defaultConfig.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Load_ProcessesElementNotPresent_ProcessesIsDefaulted()
+        {
+            this.defaultConfig.Processes.Should().NotBeNull();
         }
 
         [Fact]
@@ -50,7 +58,13 @@
         }
 
         [Fact]
-        public void Load_SdkStep_ReturnedInSdkStepesToDeactivate()
+        public void Load_SdkStepsElementNotPresent_SdkStepsIsDefaulted()
+        {
+            this.defaultConfig.SdkSteps.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Load_SdkStep_ReturnedInSdkStepsToDeactivate()
         {
             this.config.SdkStepsToDeactivate.Should().Contain(p => p.Name == "This SDK step should be deactivated");
         }
@@ -74,6 +88,12 @@
         }
 
         [Fact]
+        public void Load_SlasElementNotPresent_SlasIsDefaulted()
+        {
+            this.defaultConfig.Slas.Should().NotBeNull();
+        }
+
+        [Fact]
         public void Load_SlaIsPresent_SlaIsDeserialized()
         {
             this.config.Slas.Should().Contain(sla => sla.Name == "Standard Case SLA" && sla.IsDefault == true);
@@ -86,9 +106,21 @@
         }
 
         [Fact]
+        public void Load_DocumentTemplatesElementNotPresent_DocumentTemplatesIsDefaulted()
+        {
+            this.defaultConfig.DocumentTemplates.Should().NotBeNull();
+        }
+
+        [Fact]
         public void Load_DocumentTemplatesPopulated_DocumentTemplatesIsDeserialized()
         {
             this.config.DocumentTemplates.Should().Contain(d => d.Path == "Word Document.docx");
+        }
+
+        [Fact]
+        public void Load_DataImportsElementNotPresent_DataImportsIsDefaulted()
+        {
+            this.defaultConfig.DataImports.Should().NotBeNull();
         }
 
         [Fact]


### PR DESCRIPTION
## Purpose
A null-reference exception is thrown if there is no `<templateconfig>` element in the ImportConfig.xml file. However, this element may not be required by the consumer (e.g. they're just using connection reference setting which is done via `RuntimeSettings` or environment variables.)

## Approach
Updated `ConfigDataStorage` constructor to instantiate a `TemplateConfig`. 

Also fixed -

- Minor formatting issue in README (missing '`')
- A couple of typos in method names
- An error thrown when no SDK steps or processes are configured in the `<templateconfig>` (it was attempting to do a query using `ConditionOperator.In` and the value was empty)
- `activatedeactivateslas` now defaults to `false` (this seems to be the safer option for functionality that currently includes unwanted side-effects)

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
