### PR TITLE
fix: multiple connection references fails

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -80,12 +80,17 @@
                 throw new ArgumentNullException(nameof(values));
             }
 
-            var query = new QueryByAttribute(entity)
+            var query = new QueryExpression(entity)
             {
-                Attributes = { attribute },
                 ColumnSet = columnSet ?? new ColumnSet(false),
+                Criteria = new FilterExpression()
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression(attribute, ConditionOperator.In, values.ToArray()),
+                    },
+                },
             };
-            query.Values.AddRange(values);
 
             return this.crmSvc.RetrieveMultiple(query);
         }


### PR DESCRIPTION
## Purpose
Setting a single connection reference succeeds but setting multiple connection references fails. Another instance where `QueryByAttribute` has been used incorrectly.

## Approach
Replaces a `QueryByAttribute` with `QueryExpression`. I've checked and in the only remaining instance of `QueryByAttribute` it is being used correctly.

Azure Pipelines has been updated to include an additional connection reference mapping so this can be caught in the tests in future.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
