### PR TITLE
fix: uppercase chars in connection reference fails

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
@@ -397,7 +397,7 @@
 
             var runtimeSettingMappings = this.RuntimeSettings
                 .Where(s => s.Key.StartsWith($"{prefix}:"))
-                .ToDictionary(s => s.Key.Remove(0, prefix.Length + 1), s => s.Value.ToString());
+                .ToDictionary(kvp => kvp.Key.Remove(0, prefix.Length + 1).ToLower(), kvp => kvp.Value.ToString());
 
             this.PackageLog.Log($"{mappings.Count} matching settings found in runtime settings", TraceEventType.Verbose);
 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ConnectionReferenceDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ConnectionReferenceDeploymentService.cs
@@ -55,7 +55,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Services
                             },
                             {
                                 Constants.ConnectionReference.Fields.ConnectionId,
-                                connectionMap[e.GetAttributeValue<string>(Constants.ConnectionReference.Fields.ConnectionReferenceLogicalName)]
+                                connectionMap[e.GetAttributeValue<string>(Constants.ConnectionReference.Fields.ConnectionReferenceLogicalName).ToLower()]
                             },
                         },
                     },


### PR DESCRIPTION
## Purpose
We use and environment variables and runtime settings keys to derive the connection reference logical names to set. However, both of these have different casing conventions. This means that we need to account for difference in casing when accessing the dictionary of connections reference logical names to connection names using the logical names we have retrieved from Dataverse. This was not happening so we were getting exceptions for keys not being present in the dictionary. Fixes #37.

## Approach
Ensures that all keys in the dictionary are lowercase and that connection reference logical names retrieved from Dataverse are converted to lowercase when accessing the dictionary.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
