### PR TITLE
fix: exception thrown when no connections configured

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ConnectionReferenceDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ConnectionReferenceDeploymentService.cs
@@ -35,9 +35,11 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Services
         /// <param name="connectionMap">Connection name by connection reference ID.</param>
         public void ConnectConnectionReferences(IDictionary<string, string> connectionMap)
         {
-            if (connectionMap is null)
+            if (connectionMap is null || !connectionMap.Any())
             {
-                throw new ArgumentNullException(nameof(connectionMap));
+                this.logger.LogInformation("No connections have been configured.");
+
+                return;
             }
 
             var updateRequests = this

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ConnectionReferenceDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ConnectionReferenceDeploymentServiceTests.cs
@@ -29,11 +29,19 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.Services
         }
 
         [Fact]
-        public void ConnectConnectionReferences_NullConnectionMap_Throws()
+        public void ConnectConnectionReferences_NullConnectionMap_DoesNotThrow()
         {
             Action callingConnectConnectionReferencesWithNullConnectionMap = () => this.connectionReferenceSvc.ConnectConnectionReferences(null);
 
-            callingConnectConnectionReferencesWithNullConnectionMap.Should().Throw<ArgumentNullException>();
+            callingConnectConnectionReferencesWithNullConnectionMap.Should().NotThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ConnectConnectionReferences_EmptyConnectionMap_DoesNotThrow()
+        {
+            Action callingConnectConnectionReferencesWithNullConnectionMap = () => this.connectionReferenceSvc.ConnectConnectionReferences(new Dictionary<string, string>());
+
+            callingConnectConnectionReferencesWithNullConnectionMap.Should().NotThrow<ArgumentNullException>();
         }
 
         [Fact]


### PR DESCRIPTION
## Purpose
An exception is currently thrown if no connection references are configured.

```
2021-02-26T16:19:11.9639564Z PackageDeployer Verbose: 16 : Message: 0 matching settings found in environment variables
2021-02-26T16:19:12.0237239Z PackageDeployer Error: 2 : Message: User Code Execution : OP=AfterPrimaryImport : Status=Failed to execute Post Import Actions.  Message : The value passed for ConditionOperator.In is empty. Attribute Name: ConnectionReferenceLogicalName, Attribute Id: 64cae7dd-a639-4730-9cd8-48ca7a119457
2021-02-26T16:19:12.0237932Z Source	: mscorlib
2021-02-26T16:19:12.0238200Z Method	: HandleReturnMessage
2021-02-26T16:19:12.0238446Z Date	: 4:19:12 PM
2021-02-26T16:19:12.0238692Z Time	: 2/26/2021
2021-02-26T16:19:12.0239153Z Error	: The value passed for ConditionOperator.In is empty. Attribute Name: ConnectionReferenceLogicalName, Attribute Id: 64cae7dd-a639-4730-9cd8-48ca7a119457
2021-02-26T16:19:12.0239632Z Stack Trace	: Server stack trace: 
2021-02-26T16:19:12.0240007Z    at System.ServiceModel.Channels.ServiceChannel.HandleReply(ProxyOperationRuntime operation, ProxyRpc& rpc)
2021-02-26T16:19:12.0240555Z    at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs, TimeSpan timeout)
2021-02-26T16:19:12.0241120Z    at System.ServiceModel.Channels.ServiceChannelProxy.InvokeService(IMethodCallMessage methodCall, ProxyOperationRuntime operation)
2021-02-26T16:19:12.0241576Z    at System.ServiceModel.Channels.ServiceChannelProxy.Invoke(IMessage message)
2021-02-26T16:19:12.0241750Z 
2021-02-26T16:19:12.0241986Z Exception rethrown at [0]: 
2021-02-26T16:19:12.0242441Z    at Microsoft.Xrm.Tooling.Connector.CrmServiceClient.RetrieveMultiple(QueryBase query)
2021-02-26T16:19:12.0242938Z    at Capgemini.PowerApps.PackageDeployerTemplate.Services.ConnectionReferenceDeploymentService.GetConnectionReferences(String[] logicalNames)
2021-02-26T16:19:12.0243475Z    at Capgemini.PowerApps.PackageDeployerTemplate.Services.ConnectionReferenceDeploymentService.ConnectConnectionReferences(IDictionary`2 connectionMap)
2021-02-26T16:19:12.0244735Z    at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.<AfterPrimaryImport>b__43_0()
2021-02-26T16:19:12.0245230Z    at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.ExecuteLifecycleEvent(String eventName, Action eventAction)
2021-02-26T16:19:12.0245691Z    at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.AfterPrimaryImport()
2021-02-26T16:19:12.0246149Z    at Microsoft.Xrm.Tooling.PackageDeployment.CrmPackageCore.ImportCode.BaseImportCustomizations.ExecutePostImportActions()
2021-02-26T16:19:12.0246624Z ======================================================================================================================
2021-02-26T16:19:12.0320578Z PackageDeployer Verbose: 16 : Message: package deployment failure exception type : System.ServiceModel.FaultException`1[Microsoft.Xrm.Sdk.OrganizationServiceFault]
2021-02-26T16:19:12.0331162Z PackageDeployer Verbose: 16 : Message: converting CRM exception to error details
2021-02-26T16:19:12.0364311Z PackageDeployer Information: 8 : Message: errorDetails - ErrorCode  - -2147220989
2021-02-26T16:19:12.0370246Z PackageDeployer Information: 8 : Message: errorDetails - ErrorName  - InvalidArgument
2021-02-26T16:19:12.0377063Z PackageDeployer Information: 8 : Message: errorDetails - Message  - The value passed for ConditionOperator.In is empty. Attribute Name: ConnectionReferenceLogicalName, Attribute Id: 64cae7dd-a639-4730-9cd8-48ca7a119457
2021-02-26T16:19:12.0383754Z PackageDeployer Information: 8 : Message: errorDetails - Type  - ClientError
2021-02-26T16:19:12.0390305Z PackageDeployer Information: 8 : Message: errorDetails - StatusCode  - 400
2021-02-26T16:19:12.0395154Z PackageDeployer Information: 8 : Message: errorDetails - Source  - PackageDeployer
2021-02-26T16:19:12.0404129Z PackageDeployer Information: 8 : Message: errorDetails - TraceText  - ......Server stack trace: ......   at System.ServiceModel.Channels.ServiceChannel.HandleReply(ProxyOperationRuntime operation, ProxyRpc& rpc)......   at System.ServiceModel.Channels.ServiceChannel.Call(String action, Boolean oneway, ProxyOperationRuntime operation, Object[] ins, Object[] outs, TimeSpan timeout)......   at System.ServiceModel.Channels.ServiceChannelProxy.InvokeService(IMethodCallMessage methodCall, ProxyOperationRuntime operation)......   at System.ServiceModel.Channels.ServiceChannelProxy.Invoke(IMessage message)............Exception rethrown at [0]: ......   at Microsoft.Xrm.Tooling.Connector.CrmServiceClient.RetrieveMultiple(QueryBase query)......   at Capgemini.PowerApps.PackageDeployerTemplate.Services.ConnectionReferenceDeploymentService.GetConnectionReferences(String[] logicalNames)......   at Capgemini.PowerApps.PackageDeployerTemplate.Services.ConnectionReferenceDeploymentService.ConnectConnectionReferences(IDictionary`2 connectionMap)......   at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.<AfterPrimaryImport>b__43_0()......   at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.ExecuteLifecycleEvent(String eventName, Action eventAction)......   at Capgemini.PowerApps.PackageDeployerTemplate.PackageTemplateBase.AfterPrimaryImport()......   at Microsoft.Xrm.Tooling.PackageDeployment.CrmPackageCore.ImportCode.BaseImportCustomizations.ExecutePostImportActions()
2021-02-26T16:19:12.0407341Z PackageDeployer Information: 8 : Message: RaiseFailEvent - update progress with fail event
2021-02-26T16:19:12.0413246Z PackageDeployer Information: 8 : Message: The post-import process failed: The value passed for ConditionOperator.In is empty. Attribute Name: ConnectionReferenceLogicalName, Attribute Id: 64cae7dd-a639-4730-9cd8-48ca7a119457--Failed
2021-02-26T16:19:12.0443918Z PackageDeployer Information: 8 : Message: ****** PACKAGE DEPLOYMENT PROCESS COMPLETED. Result:FAILED  Duration:00:45:24.2643483 ******
```

## Approach
Updated to make the `ConnectionReferenceDeploymentService`  similar to `DataImporterService` - log if the connections argument is null or empty and return.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
