### PR TITLE
fix: individual issues not logged on Azure DevOps

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/AzureDevOpsTraceLoggerAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/AzureDevOpsTraceLoggerAdapter.cs
@@ -1,5 +1,6 @@
 ﻿namespace Capgemini.PowerApps.PackageDeployerTemplate.Adapters
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Tooling.PackageDeployment.CrmPackageExtentionBase;
@@ -20,17 +21,25 @@
         }
 
         /// <inheritdoc/>
-        protected override string GetPrefix(LogLevel logLevel)
+        public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
+            base.Log(logLevel, eventId, state, exception, formatter);
+
+            if (!this.IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = formatter(state, exception);
             switch (logLevel)
             {
                 case LogLevel.Warning:
-                    return "##[task.logissue type=warning]";
+                    Console.Write($"##[task.logissue type=warning]{message}");
+                    break;
                 case LogLevel.Error:
                 case LogLevel.Critical:
-                    return "##[task.logissue type=error]";
-                default:
-                    return string.Empty;
+                    Console.WriteLine($"##[task.logissue type=error]{message}");
+                    break;
             }
         }
     }

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/TraceLoggerAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/TraceLoggerAdapter.cs
@@ -56,7 +56,7 @@
         public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
 
         /// <inheritdoc/>
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             if (!this.IsEnabled(logLevel))
             {
@@ -74,18 +74,8 @@
             }
 
             this.traceLogger.Log(
-                $"{this.GetPrefix(logLevel)}{message} {(exception != null ? exception.StackTrace : string.Empty)}",
+                $"{message} {(exception != null ? exception.StackTrace : string.Empty)}",
                 LogLevelMap[logLevel]);
-        }
-
-        /// <summary>
-        /// Gets the prefix for a given log level.
-        /// </summary>
-        /// <param name="logLevel">The log level.</param>
-        /// <returns>The prefix.</returns>
-        protected virtual string GetPrefix(LogLevel logLevel)
-        {
-            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
## Purpose
The issues were not logged because the logging commands were put through the `PackageLog`. Resolves #45.

## Approach
Puts the logging commands through `Console.WriteLine`

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [x] Build and tests successful
