### PR TITLE
fix: incorrect logging commands used for issues

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/AzureDevOpsTraceLoggerAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/AzureDevOpsTraceLoggerAdapter.cs
@@ -34,11 +34,11 @@
             switch (logLevel)
             {
                 case LogLevel.Warning:
-                    Console.Write($"##[task.logissue type=warning]{message}");
+                    Console.WriteLine($"##vso[task.logissue type=warning]{message}");
                     break;
                 case LogLevel.Error:
                 case LogLevel.Critical:
-                    Console.WriteLine($"##[task.logissue type=error]{message}");
+                    Console.WriteLine($"##vso[task.logissue type=error]{message}");
                     break;
             }
         }


### PR DESCRIPTION
## Purpose
Individual issues are not being logged as part of the pipeline due to the syntax used.

## Approach
Replaces `##` with `##vso`

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
