### PR TITLE
fix: capture package solutions no matter if they were installed or not

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
@@ -89,7 +89,7 @@
         protected IDictionary<string, string> PowerAppsEnvironmentVariables => this.GetSettings(Constants.Settings.PowerAppsEnvironmentVariablePrefix);
 
         /// <summary>
-        /// Gets a list of solutions that have been processed (i.e. <see cref="PreSolutionImport(string, bool, bool, out bool, out bool)"/> has been ran for that solution.)
+        /// Gets a list of solutions that have been processed (i.e. <see cref="OverrideSolutionImportDecision"/> has been ran for that solution.)
         /// </summary>
         protected IList<string> ProcessedSolutions
         {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/PackageTemplateBase.cs
@@ -332,14 +332,14 @@
         }
 
         /// <inheritdoc/>
-        public override void PreSolutionImport(string solutionName, bool solutionOverwriteUnmanagedCustomizations, bool solutionPublishWorkflowsAndActivatePlugins, out bool overwriteUnmanagedCustomizations, out bool publishWorkflowsAndActivatePlugins)
+        public override UserRequestedImportAction OverrideSolutionImportDecision(string solutionUniqueName, Version organizationVersion, Version packageSolutionVersion, Version inboundSolutionVersion, Version deployedSolutionVersion, ImportAction systemSelectedImportAction)
         {
-            base.PreSolutionImport(solutionName, solutionOverwriteUnmanagedCustomizations, solutionPublishWorkflowsAndActivatePlugins, out overwriteUnmanagedCustomizations, out publishWorkflowsAndActivatePlugins);
-
-            this.ExecuteLifecycleEvent(nameof(this.PreSolutionImport), () =>
+            this.ExecuteLifecycleEvent($"{nameof(this.OverrideSolutionImportDecision)}({solutionUniqueName})", () =>
             {
-                this.ProcessedSolutions.Add(solutionName);
+                this.ProcessedSolutions.Add(solutionUniqueName);
             });
+
+            return base.OverrideSolutionImportDecision(solutionUniqueName, organizationVersion, packageSolutionVersion, inboundSolutionVersion, deployedSolutionVersion, systemSelectedImportAction);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Purpose
Please read the related issue #57.

## Approach
Move capture of solutions from `PreSolutionImport` to `OverrideSolutionImportDecision`. This is because `PreSolutionImport` is only executed before the solution install which may not happen if the solution version match. `OverrideSolutionImportDecision` should always be called. 

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
