### PR TITLE
tests: improve integration test success

### DIFF
--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/App.config
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.diagnosticMessages" value="true"/>
+  </appSettings>
+</configuration>

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/App.config
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/App.config
@@ -2,5 +2,6 @@
 <configuration>
   <appSettings>
     <add key="xunit.diagnosticMessages" value="true"/>
+    <add key="MaxCrmConnectionTimeOutMinutes" value="5"/>
   </appSettings>
 </configuration>

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
@@ -120,6 +120,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests
 
             solutionRecord.ToList().ForEach(solution =>
             {
+                CrmServiceClient.MaxConnectionTimeout = new TimeSpan(0, minutes: 5, 0);
                 this.ServiceClient.Delete(Constants.Solution.LogicalName, solution.Id);
             });
         }

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
@@ -13,6 +13,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests
     public class PackageDeployerFixture : IDisposable
     {
         private readonly IMessageSink diagnosticMessageSink;
+        
         public PackageDeployerFixture(IMessageSink diagnosticMessageSink)
         {
             this.diagnosticMessageSink = diagnosticMessageSink;

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
@@ -13,7 +13,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests
     public class PackageDeployerFixture : IDisposable
     {
         private readonly IMessageSink diagnosticMessageSink;
-        
+
         public PackageDeployerFixture(IMessageSink diagnosticMessageSink)
         {
             this.diagnosticMessageSink = diagnosticMessageSink;

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
@@ -12,7 +12,6 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests
 
     public class PackageDeployerFixture : IDisposable
     {
-
         public PackageDeployerFixture(IMessageSink diagnosticMessageSink)
         {
             // Check values are set.


### PR DESCRIPTION
## Purpose
This PR will resolve the following issues:
- #14 to show the Package Deployer output with the test output
- #54 to extend the request timeout while uninstalling the mock solution

## Approach
For the first issue, this is resolved by redirecting the process output via a xUnit diagnostic message. I don't think this is the best solution as the standard and error outputs are separated and these aren't "piped" but rather dumped after the process completion. I have tried to resolve that although it led to never-ending tests. 

For the second issue, I have modified the default `CrmServiceClient` timeout. This is difficult to test and therefore verify if this resolves the issue. 

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
