### PR TITLE
feat: log actual error when activating processes

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -134,7 +134,7 @@
                 }
                 catch (Exception ex)
                 {
-                    this.logger.LogError(ex, $"Status for process {deployedProcess.Attributes[Constants.Workflow.Fields.Name]} could not be set. Please check the processes for errors e.g. missing reference data or connections.");
+                    this.logger.LogError(ex, $"Status for process {deployedProcess.Attributes[Constants.Workflow.Fields.Name]} could not be set. {ex.Message}");
                 }
             }
         }


### PR DESCRIPTION
## Purpose
When a Flow fails to activate, the deployer doesn't return the actual message returned by the Power Platform. 

## Approach
Add the actual error message to the log statement. 

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
