### PR TITLE
fix: log error before falling back to deployment user

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -250,7 +250,7 @@
                 }
                 else
                 {
-                    this.logger.LogWarning(ex, $"Failed to execute {request.RequestName} as {username}.");
+                    this.logger.LogWarning(ex, $"Failed to execute {request.RequestName} as {username}. {ex.Message}");
                 }
 
                 if (!fallbackToExistingUser)


### PR DESCRIPTION
## Purpose
When impersonating another user and the request fails, the error message is not logged before retrying with the deployment user. It would be valuable to understand why the request failed. 

## Approach
Concatenate the request's error message.

## TODOs
- [ ] Automated test coverage for new code
- [x] Documentation updated (if required)
- [ ] Build and tests successful
