### PR TITLE
fix: redundant requests when setting states

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -50,6 +50,36 @@
         }
 
         /// <inheritdoc/>
+        public ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, string username, bool continueOnError = true, bool returnResponses = true)
+        {
+            if (requests is null)
+            {
+                throw new ArgumentNullException(nameof(requests));
+            }
+
+            if (username is null)
+            {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            this.logger.LogDebug($"Executing {requests.Count()} requests as {username}.");
+
+            var previousCallerObjectId = this.CallerAADObjectId;
+            ExecuteMultipleResponse response = null;
+            try
+            {
+                this.CallerAADObjectId = this.RetrieveAzureAdObjectIdByDomainName(username);
+                response = this.ExecuteMultiple(requests, continueOnError, returnResponses);
+            }
+            finally
+            {
+                this.CallerAADObjectId = previousCallerObjectId;
+            }
+
+            return response;
+        }
+
+        /// <inheritdoc/>
         public IEnumerable<Guid> RetrieveSolutionComponentObjectIds(string solutionName, int componentType)
         {
             var queryExpression = new QueryExpression(Constants.SolutionComponent.LogicalName)

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -55,6 +55,16 @@
         ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true);
 
         /// <summary>
+        /// Execute multiple requests.
+        /// </summary>
+        /// <param name="requests">The requests.</param>
+        /// <param name="username">The user to impersonate.</param>
+        /// <param name="continueOnError">Whether to continue on error.</param>
+        /// <param name="returnResponses">Whether to return responses.</param>
+        /// <returns>The <see cref="ExecuteMultipleResponse"/>.</returns>
+        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, string username, bool continueOnError = true, bool returnResponses = true);
+
+        /// <summary>
         /// Updates the state and status for an entity.
         /// </summary>
         /// <param name="entityLogicalName">The entity logical name.</param>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
@@ -105,6 +105,11 @@
                 /// The name of the process.
                 /// </summary>
                 public const string Name = "name";
+
+                /// <summary>
+                /// The name of the process.
+                /// </summary>
+                public const string StateCode = "statecode";
             }
         }
 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
@@ -209,6 +209,11 @@
                 /// The name of the SDK message processing step.
                 /// </summary>
                 public const string Name = "name";
+
+                /// <summary>
+                /// The name of the SDK message processing step.
+                /// </summary>
+                public const string StateCode = "statecode";
             }
         }
 

--- a/templates/build-and-test-job.yml
+++ b/templates/build-and-test-job.yml
@@ -84,6 +84,8 @@ jobs:
           PACKAGEDEPLOYER_SETTINGS_CONNREF_PDT_SHAREDAPPROVALS_D7DCB: $(TestEnvironment.Connection.Approvals)
           PACKAGEDEPLOYER_SETTINGS_ENVVAR_PDT_TESTVARIABLE: Any string
           PACKAGEDEPLOYER_SETTINGS_CONNBASEURL_pdt_5Fexample-20api: https://anyurl.com
+          PACKAGEDEPLOYER_SETTINGS_LICENSEDUSERNAME: ${{ parameters.username }}
+          PACKAGEDEPLOYER_SETTINGS_LICENSEDPASSWORD: ${{ parameters.password }}
         inputs:
           codeCoverageEnabled: true
           platform: '$(buildPlatform)'


### PR DESCRIPTION
## Purpose
Requests are made to activate or deactivate processes and SDK steps even when they are already at the desired state.

## Approach
Only requests to change the state when the state is different to the desired state. In addition, use ExecuteMultiple requests to avoid excessive chattiness.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
