### PR TITLE
docs: fix broken link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project's aim is to build a powerful base Package Deployer template that si
   - [SDK Steps](#SDK-stpes)
     - [Set SDK step states](#Set-sdk-step-states)
   - [Connectors](#Connectors)
-    - [Set base URLs][#Set-base-URLs]
+    - [Set base URLs](#Set-base-URLs)
   - [Connection references](#Connection-references)
     - [Set connection references](#Set-connection-references)
   - [Environment variables](#Environment-variables)


### PR DESCRIPTION
## Purpose
README Markdown syntax was slightly off resulting in a broken link.

## Approach
Fixes the Markdown syntax.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
