### PR TITLE
fix: activating processes timing out

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,9 @@ stages:
       environmentDomainName: pdt-ci
   - stage: Publish
     displayName: Publish
-    dependsOn: ManualValidation
+    dependsOn: 
+      - BuildAndTest
+      - ManualValidation
     jobs:
       - job: PublishJob
         displayName: Publish 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using Microsoft.Extensions.Logging;

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -381,7 +381,7 @@
 
         private TimeSpan SetTimeout(TimeSpan timeout)
         {
-            var previousTimeout = TimeSpan.Zero;
+            TimeSpan previousTimeout;
 
             if (this.crmSvc.OrganizationServiceProxy != null)
             {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -51,8 +51,20 @@
         /// <param name="requests">The requests.</param>
         /// <param name="continueOnError">Whether to continue on error.</param>
         /// <param name="returnResponses">Whether to return responses.</param>
+        /// <param name="timeout">Timeout in seconds.</param>
         /// <returns>The <see cref="ExecuteMultipleResponse"/>.</returns>
-        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true);
+        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true, int? timeout = null);
+
+        /// <summary>
+        /// Execute multiple requests.
+        /// </summary>
+        /// <param name="requests">The requests.</param>
+        /// <param name="username">The user to impersonate.</param>
+        /// <param name="continueOnError">Whether to continue on error.</param>
+        /// <param name="returnResponses">Whether to return responses.</param>
+        /// <param name="timeout">Timeout in seconds.</param>
+        /// <returns>The <see cref="ExecuteMultipleResponse"/>.</returns>
+        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, string username, bool continueOnError = true, bool returnResponses = true, int? timeout = null);
 
         /// <summary>
         /// Execute multiple requests.

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
@@ -131,7 +131,7 @@
                 return;
             }
 
-            var executeMultipleRes = this.crmSvc.ExecuteMultiple(requests, true, true);
+            var executeMultipleRes = this.crmSvc.ExecuteMultiple(requests, true, true, 120 + (requests.Count * 10));
 
             if (executeMultipleRes.IsFaulted)
             {


### PR DESCRIPTION
## Purpose

Switching to `ExecuteMultiple` for process activation can exceed the 2-minute timeout for solutions with large numbers of processes to activate. 

## Approach

Increases the `CrmServiceClient` timeout to 2 minutes (the default) plus an additional 10 seconds for each SDK step and process.

Also fixes an issue on the CI pipeline that results in the GitHub release version being omitted.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
