### PR TITLE
fix: process activation timeouts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,9 @@ stages:
       environmentDomainName: pdt-ci
   - stage: Publish
     displayName: Publish
-    dependsOn: ManualValidation
+    dependsOn: 
+      - BuildAndTest
+      - ManualValidation
     jobs:
       - job: PublishJob
         displayName: Publish 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -51,8 +51,9 @@
         /// <param name="requests">The requests.</param>
         /// <param name="continueOnError">Whether to continue on error.</param>
         /// <param name="returnResponses">Whether to return responses.</param>
+        /// <param name="timeout">Timeout in seconds.</param>
         /// <returns>The <see cref="ExecuteMultipleResponse"/>.</returns>
-        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true);
+        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true, int? timeout = null);
 
         /// <summary>
         /// Execute multiple requests.
@@ -61,8 +62,9 @@
         /// <param name="username">The user to impersonate.</param>
         /// <param name="continueOnError">Whether to continue on error.</param>
         /// <param name="returnResponses">Whether to return responses.</param>
+        /// <param name="timeout">Timeout in seconds.</param>
         /// <returns>The <see cref="ExecuteMultipleResponse"/>.</returns>
-        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, string username, bool continueOnError = true, bool returnResponses = true);
+        ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, string username, bool continueOnError = true, bool returnResponses = true, int? timeout = null);
 
         /// <summary>
         /// Updates the state and status for an entity.

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -138,8 +138,9 @@
                 return;
             }
 
+            var timeout = 120 + (requests.Count * 10);
             var executeMultipleRes = string.IsNullOrEmpty(user) ?
-                this.crmSvc.ExecuteMultiple(requests, true, true) : this.crmSvc.ExecuteMultiple(requests, user, true, true);
+                this.crmSvc.ExecuteMultiple(requests, true, true, timeout) : this.crmSvc.ExecuteMultiple(requests, user, true, true, timeout);
 
             if (executeMultipleRes.IsFaulted)
             {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/SdkStepDeploymentService.cs
@@ -131,7 +131,7 @@
                 return;
             }
 
-            var executeMultipleRes = this.crmSvc.ExecuteMultiple(requests, true, true);
+            var executeMultipleRes = this.crmSvc.ExecuteMultiple(requests, true, true, 120 + (requests.Count * 10));
 
             if (executeMultipleRes.IsFaulted)
             {

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
@@ -72,7 +72,8 @@
                         req.State.Value == Constants.Workflow.StateCodeInactive &&
                         req.Status.Value == Constants.Workflow.StatusCodeInactive)),
                 It.IsAny<bool>(),
-                It.IsAny<bool>()),
+                It.IsAny<bool>(),
+                It.IsAny<int?>()),
                 true);
 
             this.processDeploymentSvc.SetStatesBySolution(
@@ -100,7 +101,8 @@
                     It.IsAny<IEnumerable<OrganizationRequest>>(),
                     userToImpersonate,
                     It.IsAny<bool>(),
-                    It.IsAny<bool>()));
+                    It.IsAny<bool>(),
+                    It.IsAny<int?>()));
 
             this.processDeploymentSvc.SetStatesBySolution(
                 Solutions, user: userToImpersonate);
@@ -189,7 +191,8 @@
                         req.State.Value == Constants.Workflow.StateCodeInactive &&
                         req.Status.Value == Constants.Workflow.StatusCodeInactive)),
                 It.IsAny<bool>(),
-                It.IsAny<bool>()),
+                It.IsAny<bool>(),
+                It.IsAny<int?>()),
                 true);
 
             this.processDeploymentSvc.SetStates(Enumerable.Empty<string>(), new List<string>
@@ -212,7 +215,8 @@
                It.IsAny<IEnumerable<OrganizationRequest>>(),
                userToImpersonate,
                It.IsAny<bool>(),
-               It.IsAny<bool>()),
+               It.IsAny<bool>(),
+               It.IsAny<int?>()),
                true);
 
             this.processDeploymentSvc.SetStates(
@@ -276,7 +280,8 @@
                 expression = svc => svc.ExecuteMultiple(
                     It.IsAny<IEnumerable<OrganizationRequest>>(),
                     It.IsAny<bool>(),
-                    It.IsAny<bool>());
+                    It.IsAny<bool>(),
+                    It.IsAny<int?>());
             }
 
             if (response == null)

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/SdkStepsDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/SdkStepsDeploymentServiceTests.cs
@@ -71,7 +71,8 @@
                         req.State.Value == Constants.SdkMessageProcessingStep.StateCodeInactive &&
                         req.Status.Value == Constants.SdkMessageProcessingStep.StatusCodeInactive)),
                 It.IsAny<bool>(),
-                It.IsAny<bool>()),
+                It.IsAny<bool>(),
+                It.IsAny<int?>()),
                 true);
 
             this.sdkStepDeploymentSvc.SetStatesBySolution(
@@ -165,7 +166,8 @@
                         req.State.Value == Constants.SdkMessageProcessingStep.StateCodeInactive &&
                         req.Status.Value == Constants.SdkMessageProcessingStep.StatusCodeInactive)),
                 It.IsAny<bool>(),
-                It.IsAny<bool>()),
+                It.IsAny<bool>(),
+                It.IsAny<int?>()),
                 true);
 
             this.sdkStepDeploymentSvc.SetStates(Enumerable.Empty<string>(), new List<string>
@@ -226,7 +228,8 @@
                 expression = svc => svc.ExecuteMultiple(
                     It.IsAny<IEnumerable<OrganizationRequest>>(),
                     It.IsAny<bool>(),
-                    It.IsAny<bool>());
+                    It.IsAny<bool>(),
+                    It.IsAny<int?>());
             }
 
             if (response == null)

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/TableColumnProcessingServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/TableColumnProcessingServiceTests.cs
@@ -45,7 +45,7 @@
         {
             // Arrange
             this.crmServiceAdapterMock
-                .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>()))
                 .Returns(() =>
                 {
                     var responseItemCollection = new ExecuteMultipleResponseItemCollection
@@ -81,7 +81,7 @@
         {
             // Arrage
             this.crmServiceAdapterMock
-            .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>()))
             .Returns(() =>
             {
                 var responseItemCollection = new ExecuteMultipleResponseItemCollection
@@ -110,14 +110,14 @@
             // Assert
             this.loggerMock.VerifyLog(x => x.LogInformation("Adding auto-number seed request. Entity Name: test_table. Auto-number Attribute: test_autonumberone. Value: 1000"));
             this.loggerMock.VerifyLog(x => x.LogInformation("Adding auto-number seed request. Entity Name: test_table. Auto-number Attribute: test_autonumbertwo. Value: 2000"));
-            this.crmServiceAdapterMock.Verify(svc => svc.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>()));
+            this.crmServiceAdapterMock.Verify(svc => svc.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>()));
         }
 
         [Fact]
         public void ExecuteMultiple_Errors_LogErrors()
         {
             this.crmServiceAdapterMock
-            .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .Setup(x => x.ExecuteMultiple(It.IsAny<List<OrganizationRequest>>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>()))
             .Returns(() =>
             {
                 var responseItemCollection = new ExecuteMultipleResponseItemCollection


### PR DESCRIPTION
## Purpose

Switching to `ExecuteMultiple` for process activation can exceed the 2-minute timeout for solutions with large numbers of processes to activate. 

## Approach

Increases the `CrmServiceClient` timeout to 2 minutes (the default) plus an additional 10 seconds for each SDK step and process.

Also fixes an issue on the CI pipeline that results in the GitHub release version being omitted.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
