### PR TITLE
fix: activation of flows dependent on actions

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -139,15 +139,16 @@
                     .Select(r => remainingRequests[r.RequestIndex])
                     .ToList();
 
+                // Reset attempt number if there are any successful responses.
                 attempt = successfulResponses.Any() ? 1 : attempt++;
 
-                if (!successfulResponses.Any() && attempt <= maxAttempts)
+                // Delay if any flow activations failed due to failures getting metadata for actions
+                if (failedResponses.Any(f => f.Fault.ErrorCode == -2147089305 && f.Fault.Message.Contains("GetMetadataFor")) && attempt <= maxAttempts)
                 {
-                    // Short delay to account for errors such as where metadata cannot yet be retrieved by flows for newly activated actions.
-                    Thread.Sleep(1000);
+                    Thread.Sleep(10000);
                 }
             }
-            while (successfulResponses.Any() && remainingRequests.Count > 0 && attempt <= maxAttempts);
+            while (remainingRequests.Count > 0 && attempt <= maxAttempts);
 
             if (!successfulResponses.Any() && remainingRequests.Any())
             {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -146,7 +146,7 @@
                 // This is needed due to issues such as where recently activated actions are not available to flows straight away.
                 if (failedResponses.Any(f => f.Fault.ErrorCode == -2147089305 /*FlowServiceClientError*/ && attempt <= maxAttempts))
                 {
-                    Thread.Sleep(10000);
+                    Thread.Sleep(30000);
                 }
             }
             while (remainingRequests.Count > 0 && attempt <= maxAttempts);

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -140,10 +140,11 @@
                     .ToList();
 
                 // Reset attempt number if there are any successful responses.
-                attempt = successfulResponses.Any() ? 1 : attempt++;
+                attempt = successfulResponses.Any() ? 1 : attempt + 1;
 
-                // Delay if any flow activations failed due to failures getting metadata for actions
-                if (failedResponses.Any(f => f.Fault.ErrorCode == -2147089305 && f.Fault.Message.Contains("GetMetadataFor")) && attempt <= maxAttempts)
+                // Delay if any process activation errors are due to a FlowServiceClientError response.
+                // This is needed due to issues such as where recently activated actions are not available to flows straight away.
+                if (failedResponses.Any(f => f.Fault.ErrorCode == -2147089305 /*FlowServiceClientError*/ && attempt <= maxAttempts))
                 {
                     Thread.Sleep(10000);
                 }

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
@@ -3,11 +3,10 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Linq.Expressions;
+    using System.ServiceModel;
     using Capgemini.PowerApps.PackageDeployerTemplate.Adapters;
     using Capgemini.PowerApps.PackageDeployerTemplate.Services;
     using FluentAssertions;
-    using Microsoft.Crm.Sdk.Messages;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Sdk;
     using Microsoft.Xrm.Sdk.Messages;
@@ -61,20 +60,10 @@
         {
             var solutionProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeActive) };
             this.MockBySolutionProcesses(solutionProcesses);
-            this.MockExecuteMultipleResponse(
-                null,
-                svc => svc.ExecuteMultiple(
-                It.Is<IEnumerable<OrganizationRequest>>(
-                    reqs => reqs.Cast<SetStateRequest>().Any(
-                        req =>
-                        req.EntityMoniker.LogicalName == Constants.Workflow.LogicalName &&
-                        req.EntityMoniker.Id == solutionProcesses.First().Id &&
-                        req.State.Value == Constants.Workflow.StateCodeInactive &&
-                        req.Status.Value == Constants.Workflow.StatusCodeInactive)),
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<int?>()),
-                true);
+            this.crmServiceAdapterMock.Setup(
+                crmSvc => crmSvc.Execute(
+                    It.Is<UpdateRequest>(u => u.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value == Constants.Workflow.StateCodeInactive)))
+                .Verifiable();
 
             this.processDeploymentSvc.SetStatesBySolution(
                 Solutions,
@@ -95,14 +84,13 @@
                 GetProcess(Constants.Workflow.StateCodeInactive),
             };
             this.MockBySolutionProcesses(solutionProcesses);
-            this.MockExecuteMultipleResponse(
-                null,
-                svc => svc.ExecuteMultiple(
-                    It.IsAny<IEnumerable<OrganizationRequest>>(),
+
+            this.crmServiceAdapterMock.Setup(
+                crmSvc => crmSvc.Execute<UpdateResponse>(
+                    It.IsAny<OrganizationRequest>(),
                     userToImpersonate,
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<int?>()));
+                    It.IsAny<bool>()))
+                .Verifiable();
 
             this.processDeploymentSvc.SetStatesBySolution(
                 Solutions, user: userToImpersonate);
@@ -165,7 +153,10 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
-            this.MockExecuteMultipleResponse();
+            this.crmServiceAdapterMock.Setup(
+                crmSvc => crmSvc.Execute(
+                    It.Is<UpdateRequest>(u => u.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value == Constants.Workflow.StateCodeActive)))
+                .Verifiable();
 
             this.processDeploymentSvc.SetStates(new List<string>
             {
@@ -180,20 +171,10 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeActive) };
             this.MockSetStatesProcesses(foundProcesses);
-            this.MockExecuteMultipleResponse(
-                null,
-                svc => svc.ExecuteMultiple(
-                It.Is<IEnumerable<OrganizationRequest>>(
-                    reqs => reqs.Cast<SetStateRequest>().Any(
-                        req =>
-                        req.EntityMoniker.LogicalName == Constants.Workflow.LogicalName &&
-                        req.EntityMoniker.Id == foundProcesses.First().Id &&
-                        req.State.Value == Constants.Workflow.StateCodeInactive &&
-                        req.Status.Value == Constants.Workflow.StatusCodeInactive)),
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<int?>()),
-                true);
+            this.crmServiceAdapterMock.Setup(
+                crmSvc => crmSvc.Execute(
+                    It.Is<UpdateRequest>(u => u.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value == Constants.Workflow.StateCodeInactive)))
+                .Verifiable();
 
             this.processDeploymentSvc.SetStates(Enumerable.Empty<string>(), new List<string>
             {
@@ -208,17 +189,13 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
-
             var userToImpersonate = "licenseduser@domaincom";
-            this.MockExecuteMultipleResponse(
-               null,
-               svc => svc.ExecuteMultiple(
-               It.IsAny<IEnumerable<OrganizationRequest>>(),
-               userToImpersonate,
-               It.IsAny<bool>(),
-               It.IsAny<bool>(),
-               It.IsAny<int?>()),
-               true);
+            this.crmServiceAdapterMock.Setup(
+                crmSvc => crmSvc.Execute<UpdateResponse>(
+                    It.IsAny<OrganizationRequest>(),
+                    userToImpersonate,
+                    It.IsAny<bool>()))
+                .Verifiable();
 
             this.processDeploymentSvc.SetStates(
                 new List<string>
@@ -236,11 +213,10 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
-
-            var failedResponse = GetNewExecuteMultipleResponse(isFaulted: true);
-            var fault = new OrganizationServiceFault { Message = "Some error." };
-            failedResponse.Responses.Add(new ExecuteMultipleResponseItem { Fault = fault });
-            this.MockExecuteMultipleResponse(failedResponse);
+            var fault = new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), "Some error.");
+            this.crmServiceAdapterMock
+                .Setup(crmSvc => crmSvc.Execute(It.IsAny<UpdateRequest>()))
+                .Throws(fault);
 
             this.processDeploymentSvc.SetStates(
                 new List<string>
@@ -253,33 +229,25 @@
         }
 
         [Fact]
-        public void SetStates_WithError_RetriesUpToThreeTimes()
+        public void SetStates_WithError_RetriesWhenOtherRequestsAreSuccessful()
         {
-            var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
+            var foundProcesses = new List<Entity>
+            {
+                GetProcess(Constants.Workflow.StateCodeInactive),
+                GetProcess(Constants.Workflow.StateCodeInactive),
+            };
             this.MockSetStatesProcesses(foundProcesses);
-
-            var failedResponse = GetNewExecuteMultipleResponse(isFaulted: true);
-            failedResponse.Responses.Add(new ExecuteMultipleResponseItem { Fault = new OrganizationServiceFault { Message = "Flow error." } });
-
-            var successfulResponse = GetNewExecuteMultipleResponse(isFaulted: false);
-            successfulResponse.Responses.Add(new ExecuteMultipleResponseItem());
-
-            this.MockExecuteMultipleResponses(failedResponse, failedResponse, successfulResponse);
+            var fault = new FaultException<OrganizationServiceFault>(new OrganizationServiceFault());
+            this.crmServiceAdapterMock
+                .SetupSequence(crmSvc => crmSvc.Execute(It.IsAny<UpdateRequest>()))
+                .Throws(fault)
+                .Returns(new UpdateResponse());
 
             this.processDeploymentSvc.SetStates(
-                new List<string>
-                {
-                    foundProcesses.First().GetAttributeValue<string>(Constants.Workflow.Fields.Name),
-                },
+                foundProcesses.Select(p => p.GetAttributeValue<string>(Constants.Workflow.Fields.Name)).ToList(),
                 Enumerable.Empty<string>());
 
-            this.crmServiceAdapterMock.Verify(
-                svc => svc.ExecuteMultiple(
-                    It.IsAny<IEnumerable<OrganizationRequest>>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<int?>()),
-                Times.Exactly(3));
+            this.crmServiceAdapterMock.Verify(svc => svc.Execute(It.IsAny<UpdateRequest>()), Times.Exactly(3));
         }
 
         [Fact]
@@ -288,11 +256,13 @@
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
 
-            var failedResponse = GetNewExecuteMultipleResponse(isFaulted: true);
-            var fault = new OrganizationServiceFault { Message = "Some error." };
-            failedResponse.Responses.Add(new ExecuteMultipleResponseItem { Fault = fault });
-
-            this.MockExecuteMultipleResponses(failedResponse, failedResponse, failedResponse);
+            var faultException = new FaultException<OrganizationServiceFault>(
+                new OrganizationServiceFault { Message = "Some message." });
+            this.crmServiceAdapterMock
+                .SetupSequence(crmSvc => crmSvc.Execute(It.IsAny<UpdateRequest>()))
+                .Throws(faultException)
+                .Throws(faultException)
+                .Returns(new UpdateResponse());
 
             this.processDeploymentSvc.SetStates(
                 new List<string>
@@ -301,19 +271,7 @@
                 },
                 Enumerable.Empty<string>());
 
-            this.loggerMock.VerifyLog(l => l.LogError(It.Is<string>(s => s.Contains(fault.Message))));
-        }
-
-        private static ExecuteMultipleResponse GetNewExecuteMultipleResponse(bool isFaulted)
-        {
-            return new ExecuteMultipleResponse
-            {
-                Results = new ParameterCollection
-                {
-                    { "Responses", new ExecuteMultipleResponseItemCollection() },
-                    { "IsFaulted", isFaulted },
-                },
-            };
+            this.loggerMock.VerifyLog(l => l.LogError(It.Is<string>(s => s.Contains(faultException.Message))));
         }
 
         private static Entity GetProcess(int stateCode)
@@ -323,56 +281,13 @@
                 Attributes =
                     {
                         {
-                            Constants.Workflow.Fields.Name, "Process"
+                            Constants.Workflow.Fields.Name, $"Process {Guid.NewGuid()}"
                         },
                         {
                             Constants.Workflow.Fields.StateCode, new OptionSetValue(stateCode)
                         },
                     },
             };
-        }
-
-        private void MockExecuteMultipleResponse(ExecuteMultipleResponse response = null, Expression<Func<ICrmServiceAdapter, ExecuteMultipleResponse>> expression = null, bool verifiable = false)
-        {
-            if (expression == null)
-            {
-                expression = svc => svc.ExecuteMultiple(
-                    It.IsAny<IEnumerable<OrganizationRequest>>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<int?>());
-            }
-
-            if (response == null)
-            {
-                response = new ExecuteMultipleResponse();
-                response.Results["Responses"] = new ExecuteMultipleResponseItemCollection();
-            }
-
-            var returnResult = this.crmServiceAdapterMock
-                .Setup(expression)
-                .Returns(response);
-
-            if (verifiable)
-            {
-                returnResult.Verifiable();
-            }
-        }
-
-        private void MockExecuteMultipleResponses(params ExecuteMultipleResponse[] responses)
-        {
-            var setup = this.crmServiceAdapterMock
-                .SetupSequence(svc =>
-                    svc.ExecuteMultiple(
-                        It.IsAny<IEnumerable<OrganizationRequest>>(),
-                        It.IsAny<bool>(),
-                        It.IsAny<bool>(),
-                        It.IsAny<int?>()));
-
-            foreach (var response in responses)
-            {
-                setup.Returns(response);
-            }
         }
 
         private void MockSetStatesProcesses(IList<Entity> processes)


### PR DESCRIPTION
## Purpose
Activating flows immediately after actions they're dependent on fails due to them being unable to retrieve the metadata. There is a short delay after activating an action before which these flows are able to be activated.

## Approach
Introduces multiple attempts to activate processes and will delay for 10 seconds where there are any failure responses due to the above issue.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
