### PR TITLE
fix: environment variable failures if not found

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/EnvironmentVariableDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/EnvironmentVariableDeploymentService.cs
@@ -65,7 +65,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Services
             var definition = this.GetDefinitionByKey(key, new ColumnSet(false));
             if (definition == null)
             {
-                this.logger.LogError($"Environment variable {key} not found on target instance.");
+                this.logger.LogInformation($"Environment variable {key} not found on target instance.");
                 return;
             }
 


### PR DESCRIPTION
Deployment fails when an environment variable is not found #80

## Purpose
Deployment fails when an environment variable key which has been found (e.g. in an Azure DevOps variable group) is not found on the target environment.

## Approach
Instead of logging this as error, we should log this as information to prevent failure of the deployment.

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
