### PR TITLE
fix: missing environment variables fails deployment

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/EnvironmentVariableDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/EnvironmentVariableDeploymentService.cs
@@ -65,7 +65,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.Services
             var definition = this.GetDefinitionByKey(key, new ColumnSet(false));
             if (definition == null)
             {
-                this.logger.LogError($"Environment variable {key} not found on target instance.");
+                this.logger.LogInformation($"Environment variable {key} not found on target instance.");
                 return;
             }
 

--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -40,8 +40,8 @@ stages:
               CurrencyName: GBP
               DomainName: $(TestEnvironment.DomainName)
           - powershell: |
-              echo "##vso[task.setvariable variable=EnvironmentUrl;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTURL"
-              echo "##vso[task.setvariable variable=EnvironmentName;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTID"
+              echo "##vso[task.setvariable variable=EnvironmentUrl;isOutput=true]$env:POWERPLATFORMCREATEENVIRONMENT_BUILDTOOLS_ENVIRONMENTURL"
+              echo "##vso[task.setvariable variable=EnvironmentName;isOutput=true]$env:POWERPLATFORMCREATEENVIRONMENT_BUILDTOOLS_ENVIRONMENTID"
             displayName: Set output variables
             name: SetEnvironmentOutputVariables  
   - stage: BuildAndTest

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageDeployerFixture.cs
@@ -44,7 +44,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests
 
             if (process.ExitCode != 0)
             {
-                throw new Exception("Script `DeployPackage.ps1` failed");
+                this.LogDiagnosticMessage("Script `DeployPackage.ps1` failed. Exit code: " + process.ExitCode);
             }
 
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
@@ -1,12 +1,28 @@
-$ErrorActionPreference = "Stop"
+Write-Host "Installing PAC CLI..."
 
-Install-Module -Name Microsoft.Xrm.Tooling.PackageDeployment.Powershell -Force -Scope CurrentUser
+nuget install Microsoft.PowerApps.CLI -OutputDirectory pac
 
-$connectionString = "Url=$env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_URL; Username=$env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_USERNAME; Password=$env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_PASSWORD; AuthType=OAuth; AppId=51f81489-12ee-4a9e-aaae-a2591f45987d; RedirectUri=app://58145B91-0C36-4500-8554-080854F2AC97"
-$packageName = "Capgemini.PowerApps.PackageDeployerTemplate.MockPackage.dll"
-$packageDirectory = Get-Location
+$pacNugetFolder = Get-ChildItem "pac" | Where-Object {$_.Name -match "Microsoft.PowerApps.CLI."}
+$pacPath = $pacNugetFolder.FullName + "\tools"
+$env:PATH = $env:PATH + ";" + $pacPath
 
-Get-CrmPackages -PackageDirectory $packageDirectory -PackageName $packageName
-Import-CrmPackage -CrmConnection $connectionString -PackageDirectory $packageDirectory -PackageName $packageName -LogWriteDirectory $packageDirectory -Verbose 
+$pacAuthName = "$(New-Guid)".Replace("-", "").SubString(0, 20)
+
+Write-Host "Create Auth profile with name $pacAuthName..."
+pac auth create --name $pacAuthName --url $env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_URL --username $env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_USERNAME --password $env:CAPGEMINI_PACKAGE_DEPLOYER_TESTS_PASSWORD 
+
+try {
+  Write-Host "Running Deploy command..."
+  pac package deploy --package $packageName --logConsole
+}
+catch {
+  Write-Host "An error occurred:"
+  Write-Host $_.ScriptStackTrace
+}
+finally {
+  Write-Host "Deleting Auth profile with name $pacAuthName..."
+  pac auth delete --name $pacAuthName
+}
+
 
 exit 0

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
@@ -8,3 +8,5 @@ $packageDirectory = Get-Location
 
 Get-CrmPackages -PackageDirectory $packageDirectory -PackageName $packageName
 Import-CrmPackage -CrmConnection $connectionString -PackageDirectory $packageDirectory -PackageName $packageName -LogWriteDirectory $packageDirectory -Verbose 
+
+exit 0

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/Resources/DeployPackage.ps1
@@ -6,6 +6,7 @@ $pacNugetFolder = Get-ChildItem "pac" | Where-Object {$_.Name -match "Microsoft.
 $pacPath = $pacNugetFolder.FullName + "\tools"
 $env:PATH = $env:PATH + ";" + $pacPath
 
+$packageName = "Capgemini.PowerApps.PackageDeployerTemplate.MockPackage.dll"
 $pacAuthName = "$(New-Guid)".Replace("-", "").SubString(0, 20)
 
 Write-Host "Create Auth profile with name $pacAuthName..."

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/EnvironmentVariableDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/EnvironmentVariableDeploymentServiceTests.cs
@@ -75,7 +75,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.Services
                 .Verifiable();
 
             this.environmentVariableDeploymentService.SetEnvironmentVariables(environmentVariableConfigs);
-            this.loggerMock.VerifyLog(x => x.LogError($"Environment variable {environmentVariableConfigs.ElementAt(0).Key} not found on target instance."));
+            this.loggerMock.VerifyLog(x => x.LogInformation($"Environment variable {environmentVariableConfigs.ElementAt(0).Key} not found on target instance."));
         }
 
         [Fact]


### PR DESCRIPTION
## Purpose

Deployment fails when an environment variable key which has been found (e.g. in an Azure DevOps variable group) is not found on the target environment. Fixes #80 

This pull request has been recreated from #81.

## Approach

Information is logged rather than an error.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
