### PR TITLE
ci: revert change of build tool environment variables

### DIFF
--- a/templates/build-and-test-stages.yml
+++ b/templates/build-and-test-stages.yml
@@ -40,8 +40,8 @@ stages:
               CurrencyName: GBP
               DomainName: $(TestEnvironment.DomainName)
           - powershell: |
-              echo "##vso[task.setvariable variable=EnvironmentUrl;isOutput=true]$env:POWERPLATFORMCREATEENVIRONMENT_BUILDTOOLS_ENVIRONMENTURL"
-              echo "##vso[task.setvariable variable=EnvironmentName;isOutput=true]$env:POWERPLATFORMCREATEENVIRONMENT_BUILDTOOLS_ENVIRONMENTID"
+              echo "##vso[task.setvariable variable=EnvironmentUrl;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTURL"
+              echo "##vso[task.setvariable variable=EnvironmentName;isOutput=true]$env:BUILDTOOLS_ENVIRONMENTID"
             displayName: Set output variables
             name: SetEnvironmentOutputVariables  
   - stage: BuildAndTest


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issue(s)._
The Power Platform BUild Tools made a change to the environment variables they set. We fixed the build at the time but they have since reverted.

## Approach
_How does this change address the problem?_

## TODOs
- [ ] Automated test coverage for new code
- [ ] Documentation updated (if required)
- [ ] Build and tests successful
