### PR TITLE
fix: failures activating action dependent flows

### DIFF
--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -432,7 +432,11 @@
         /// <inheritdoc/>
         public IDictionary<OrganizationRequest, OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null)
         {
-            return requests.ToDictionary(r => r, r =>
+            // Errors are expected and caught and handled. Uncaught errors are handled and logged via the onError callback.
+            var previousTraceLevel = TraceControlSettings.TraceLevel;
+            TraceControlSettings.TraceLevel = System.Diagnostics.SourceLevels.Off;
+
+            var results = requests.ToDictionary(r => r, r =>
             {
                 try
                 {
@@ -466,6 +470,10 @@
 
                 return null;
             });
+
+            TraceControlSettings.TraceLevel = previousTraceLevel;
+
+            return results;
         }
 
         /// <inheritdoc/>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -5,7 +5,9 @@
     using System.IO;
     using System.Linq;
     using System.ServiceModel;
+    using System.Web.Configuration;
     using Capgemini.PowerApps.PackageDeployerTemplate.Exceptions;
+    using DocumentFormat.OpenXml.Office2016.Excel;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Sdk;
     using Microsoft.Xrm.Sdk.Messages;
@@ -292,7 +294,7 @@
         }
 
         /// <inheritdoc/>
-        public TResponse Execute<TResponse>(OrganizationRequest request, string username, bool fallbackToExistingUser = true)
+        public TResponse Execute<TResponse>(OrganizationRequest request, string username, bool fallbackToExistingUser = true, bool logErrors = true)
             where TResponse : OrganizationResponse
         {
             if (request is null)
@@ -320,7 +322,7 @@
                 {
                     this.logger.LogWarning($"Failed to execute {request.RequestName} as {username} as the user was not found.");
                 }
-                else
+                else if (logErrors)
                 {
                     this.logger.LogWarning(ex, $"Failed to execute {request.RequestName} as {username}. {ex.Message}");
                 }
@@ -428,63 +430,42 @@
         }
 
         /// <inheritdoc/>
-        public IEnumerable<OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null)
+        public IDictionary<OrganizationRequest, OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null)
         {
-            var responses = requests.ToDictionary(r => r, r => (OrganizationResponse)null);
-            var remainingRequests = requests.Reverse().ToList();
-
-            while (remainingRequests.Any())
+            return requests.ToDictionary<OrganizationRequest, OrganizationRequest, OrganizationResponse>(r => r, r =>
             {
-                var exceptions = remainingRequests.ToDictionary(r => r, r => (Exception)null);
-                var initialRequestCount = remainingRequests.Count;
-
-                for (int i = remainingRequests.Count - 1; i >= 0; i--)
+                try
                 {
-                    try
+                    this.CustomizationLockPolicy.Execute(() =>
                     {
-                        this.CustomizationLockPolicy.Execute(() =>
+                        try
                         {
-                            try
+                            if (string.IsNullOrEmpty(username))
                             {
-                                if (string.IsNullOrEmpty(username))
-                                {
-                                    responses[remainingRequests[i]] = this.crmSvc.Execute(remainingRequests[i]);
-                                }
+                                return this.crmSvc.Execute(r);
+                            }
 
-                                responses[remainingRequests[i]] = this.Execute<OrganizationResponse>(remainingRequests[i], username, true);
-                            }
-                            catch (FaultException<OrganizationServiceFault> ex) when (ex.Detail.ErrorCode == Constants.ErrorCodes.SolutionConcurrencyFailure)
-                            {
-                                throw new SolutionConcurrencyException($"Request failed due to solution concurrency errors.");
-                            }
-                            catch (FaultException<OrganizationServiceFault> ex) when (CustomizationLockErrorCodes.Contains(ex.Detail.ErrorCode))
-                            {
-                                throw new CustomizationLockException($"Request failed due to customization lock errors.");
-                            }
-                        });
-
-                        remainingRequests.RemoveAt(i);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Swallow and leave in remaining requests - possibly an activation order issue.
-                        exceptions[remainingRequests[i]] = ex;
-                    }
+                            return this.Execute<OrganizationResponse>(r, username, false, false);
+                        }
+                        catch (FaultException<OrganizationServiceFault> ex) when (ex.Detail.ErrorCode == Constants.ErrorCodes.SolutionConcurrencyFailure)
+                        {
+                            // Policy will handle this exception.
+                            throw new SolutionConcurrencyException($"Request failed due to solution concurrency errors.");
+                        }
+                        catch (FaultException<OrganizationServiceFault> ex) when (CustomizationLockErrorCodes.Contains(ex.Detail.ErrorCode))
+                        {
+                            // Policy will handle this exception.
+                            throw new CustomizationLockException($"Request failed due to customization lock errors.");
+                        }
+                    });
                 }
-
-                if (initialRequestCount == remainingRequests.Count)
+                catch (Exception ex)
                 {
-                    // No new successes this iteration.
-                    foreach (var kvp in exceptions.Where(kvp => kvp.Value != null))
-                    {
-                        onError(kvp.Key, kvp.Value);
-                    }
-
-                    break;
+                    onError(r, ex);
                 }
-            }
 
-            return responses.Values;
+                return null;
+            });
         }
 
         /// <inheritdoc/>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -432,11 +432,11 @@
         /// <inheritdoc/>
         public IDictionary<OrganizationRequest, OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null)
         {
-            return requests.ToDictionary<OrganizationRequest, OrganizationRequest, OrganizationResponse>(r => r, r =>
+            return requests.ToDictionary(r => r, r =>
             {
                 try
                 {
-                    this.CustomizationLockPolicy.Execute(() =>
+                    return this.CustomizationLockPolicy.Execute(() =>
                     {
                         try
                         {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/CrmServiceAdapter.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.ServiceModel;
     using Capgemini.PowerApps.PackageDeployerTemplate.Exceptions;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Sdk;
@@ -17,8 +18,19 @@
     /// </summary>
     public class CrmServiceAdapter : ICrmServiceAdapter, IDisposable
     {
+        private static readonly int[] CustomizationLockErrorCodes = new int[]
+        {
+            Constants.ErrorCodes.CustomizationLockExBlockingUnknown,
+            Constants.ErrorCodes.CustomizationLockExBothKnownDifferent,
+            Constants.ErrorCodes.CustomizationLockExBothKnownSame,
+            Constants.ErrorCodes.CustomizationLockExBlockedUnknown,
+            Constants.ErrorCodes.CustomizationLockExBothUnknown,
+        };
+
         private readonly CrmServiceClient crmSvc;
         private readonly ILogger logger;
+
+        private Policy customizationLockPolicy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CrmServiceAdapter"/> class.
@@ -33,6 +45,24 @@
 
         /// <inheritdoc/>
         public Guid? CallerAADObjectId { get => this.crmSvc.CallerAADObjectId; set => this.crmSvc.CallerAADObjectId = value; }
+
+        private Policy CustomizationLockPolicy
+        {
+            get
+            {
+                this.customizationLockPolicy ??= Policy
+                        .Handle<CustomizationLockException>()
+                        .RetryForever(_ => this.WaitForSolutionHistoryRecordsToComplete())
+                        .Wrap(
+                            Policy
+                            .Handle<SolutionConcurrencyException>()
+                            .WaitAndRetryForever(
+                                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(30),
+                                onRetry: (_, timeSpan) => this.logger.LogInformation("A solution concurrency issue has occured.  Waiting for {0} seconds before retrying.", timeSpan.TotalSeconds)));
+
+                return this.customizationLockPolicy;
+            }
+        }
 
         /// <inheritdoc/>
         public ExecuteMultipleResponse ExecuteMultiple(IEnumerable<OrganizationRequest> requests, bool continueOnError = true, bool returnResponses = true, int? timeout = null)
@@ -342,31 +372,13 @@
         }
 
         /// <inheritdoc/>
+        [Obsolete("Please use ExecuteManySolutionHistoryOperation.", true)]
         public IEnumerable<ExecuteMultipleResponseItem> ExecuteMultipleSolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, int? timeout = null)
         {
-            var customizationLockErrorCodes = new int[]
-            {
-                Constants.ErrorCodes.CustomizationLockExBlockingUnknown,
-                Constants.ErrorCodes.CustomizationLockExBothKnownDifferent,
-                Constants.ErrorCodes.CustomizationLockExBothKnownSame,
-                Constants.ErrorCodes.CustomizationLockExBlockedUnknown,
-                Constants.ErrorCodes.CustomizationLockExBothUnknown,
-            };
-
             var firstIndexByRequest = requests.ToDictionary(request => request, request => default(int?));
             var responseByRequest = requests.ToDictionary(request => request, request => (ExecuteMultipleResponseItem)null);
 
-            var retryPolicy = Policy
-                .Handle<CustomizationLockException>()
-                .RetryForever(_ => this.WaitForSolutionHistoryRecordsToComplete())
-                .Wrap(
-                    Policy
-                    .Handle<SolutionConcurrencyException>()
-                    .WaitAndRetryForever(
-                        sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(30),
-                        onRetry: (_, timeSpan) => this.logger.LogInformation("A solution concurrency issue has occured.  Waiting for {0} seconds before retrying.", timeSpan.TotalSeconds)));
-
-            retryPolicy.Execute(() =>
+            this.CustomizationLockPolicy.Execute(() =>
             {
                 var res = string.IsNullOrEmpty(username)
                     ? this.ExecuteMultiple(requests, true, true, timeout)
@@ -384,24 +396,26 @@
                     responseByRequest[request] = response;
                 }
 
-                if (res.IsFaulted)
+                if (!res.IsFaulted)
                 {
-                    requests = res.Responses
-                        .Where(r => r.Fault != null)
-                        .Select(r => requests.ElementAt(r.RequestIndex))
-                        .ToList();
+                    return;
+                }
 
-                    var solutionConcurrencyErrors = res.Responses.Where(r => r.Fault?.ErrorCode == Constants.ErrorCodes.SolutionConcurrencyFailure);
-                    if (solutionConcurrencyErrors.Any())
-                    {
-                        throw new SolutionConcurrencyException($"{solutionConcurrencyErrors.Count()} requests failed due to solution concurrency errors.");
-                    }
+                requests = res.Responses
+                    .Where(r => r.Fault != null)
+                    .Select(r => requests.ElementAt(r.RequestIndex))
+                    .ToList();
 
-                    var customizationLockErrors = res.Responses.Where(r => r.Fault != null && customizationLockErrorCodes.Contains(r.Fault.ErrorCode));
-                    if (customizationLockErrors.Any())
-                    {
-                        throw new CustomizationLockException($"{customizationLockErrors.Count()} requests failed due to customization lock errors.");
-                    }
+                var solutionConcurrencyErrors = res.Responses.Where(r => r.Fault?.ErrorCode == Constants.ErrorCodes.SolutionConcurrencyFailure);
+                if (solutionConcurrencyErrors.Any())
+                {
+                    throw new SolutionConcurrencyException($"{solutionConcurrencyErrors.Count()} requests failed due to solution concurrency errors.");
+                }
+
+                var customizationLockErrors = res.Responses.Where(r => r.Fault != null && CustomizationLockErrorCodes.Contains(r.Fault.ErrorCode));
+                if (customizationLockErrors.Any())
+                {
+                    throw new CustomizationLockException($"{customizationLockErrors.Count()} requests failed due to customization lock errors.");
                 }
             });
 
@@ -411,6 +425,66 @@
             }
 
             return responseByRequest.Values;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null)
+        {
+            var responses = requests.ToDictionary(r => r, r => (OrganizationResponse)null);
+            var remainingRequests = requests.Reverse().ToList();
+
+            while (remainingRequests.Any())
+            {
+                var exceptions = remainingRequests.ToDictionary(r => r, r => (Exception)null);
+                var initialRequestCount = remainingRequests.Count;
+
+                for (int i = remainingRequests.Count - 1; i >= 0; i--)
+                {
+                    try
+                    {
+                        this.CustomizationLockPolicy.Execute(() =>
+                        {
+                            try
+                            {
+                                if (string.IsNullOrEmpty(username))
+                                {
+                                    responses[remainingRequests[i]] = this.crmSvc.Execute(remainingRequests[i]);
+                                }
+
+                                responses[remainingRequests[i]] = this.Execute<OrganizationResponse>(remainingRequests[i], username, true);
+                            }
+                            catch (FaultException<OrganizationServiceFault> ex) when (ex.Detail.ErrorCode == Constants.ErrorCodes.SolutionConcurrencyFailure)
+                            {
+                                throw new SolutionConcurrencyException($"Request failed due to solution concurrency errors.");
+                            }
+                            catch (FaultException<OrganizationServiceFault> ex) when (CustomizationLockErrorCodes.Contains(ex.Detail.ErrorCode))
+                            {
+                                throw new CustomizationLockException($"Request failed due to customization lock errors.");
+                            }
+                        });
+
+                        remainingRequests.RemoveAt(i);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Swallow and leave in remaining requests - possibly an activation order issue.
+                        exceptions[remainingRequests[i]] = ex;
+                    }
+                }
+
+                if (initialRequestCount == remainingRequests.Count)
+                {
+                    // No new successes this iteration.
+                    foreach (var kvp in exceptions.Where(kvp => kvp.Value != null))
+                    {
+                        onError(kvp.Key, kvp.Value);
+                    }
+
+                    break;
+                }
+            }
+
+            return responses.Values;
         }
 
         /// <inheritdoc/>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -134,5 +134,15 @@
         /// <param name="timeout">Timeout in seconds.</param>
         /// <returns>Returns an <see cref="ExecuteMultipleResponseItem"/>.</returns>
         IEnumerable<ExecuteMultipleResponseItem> ExecuteMultipleSolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, int? timeout = null);
+
+        /// <summary>
+        /// Executes multiple requests individually and performs a check on the Solution History during the operation.
+        /// </summary>
+        /// <param name="requests">The collection of <see cref="OrganizationRequest"/> to execute.</param>
+        /// <param name="username">The user to impersonate.</param>
+        /// <param name="onError">An action to be called for each errored request.</param>
+        /// <returns>Returns a collection of <see cref="OrganizationResponse"/>.</returns>
+        IEnumerable<OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null);
+
     }
 }

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Adapters/ICrmServiceAdapter.cs
@@ -90,10 +90,11 @@
         /// <param name="request">The request.</param>
         /// <param name="username">The user to impersonate.</param>
         /// <param name="fallbackToExistingUser">Whether to fallback to the authenticated user if the action fails as the specified user.</param>
+        /// <param name="logErrors">Whether to log errors.</param>
         /// <typeparam name="TResponse">The type of response.</typeparam>
         /// <returns>The response.</returns>
         /// <exception cref="ArgumentException">Thrown when the specified user doesn't exist and fallback is disabled.</exception>
-        public TResponse Execute<TResponse>(OrganizationRequest request, string username, bool fallbackToExistingUser = true)
+        public TResponse Execute<TResponse>(OrganizationRequest request, string username, bool fallbackToExistingUser = true, bool logErrors = true)
             where TResponse : OrganizationResponse;
 
         /// <summary>
@@ -141,8 +142,7 @@
         /// <param name="requests">The collection of <see cref="OrganizationRequest"/> to execute.</param>
         /// <param name="username">The user to impersonate.</param>
         /// <param name="onError">An action to be called for each errored request.</param>
-        /// <returns>Returns a collection of <see cref="OrganizationResponse"/>.</returns>
-        IEnumerable<OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null);
-
+        /// <returns>A dictionary of responses keyed by request.</returns>
+        IDictionary<OrganizationRequest, OrganizationResponse> ExecuteManySolutionHistoryOperation(IEnumerable<OrganizationRequest> requests, string username, Action<OrganizationRequest, Exception> onError = null);
     }
 }

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
@@ -47,16 +47,6 @@
         public static class Workflow
         {
             /// <summary>
-            /// Definition option set value for type option set.
-            /// </summary>
-            public const int TypeDefinition = 1;
-
-            /// <summary>
-            /// Modern flow option set value for type option set.
-            /// </summary>
-            public const int CategoryModernFlow = 5;
-
-            /// <summary>
             /// The logical name.
             /// </summary>
             public const string LogicalName = "workflow";
@@ -116,6 +106,78 @@
                 /// </summary>
                 public const string StatusCode = "statuscode";
             }
+        }
+
+        /// <summary>
+        /// Workflow types.
+        /// </summary>
+        public static class WorkflowType
+        {
+            /// <summary>
+            /// Workflow type for definition workflows.
+            /// </summary>
+            public const int Definition = 1;
+
+            /// <summary>
+            /// Workflow type for activation workflows.
+            /// </summary>
+            public const int Activation = 2;
+
+            /// <summary>
+            /// Workflow type for template workflows.
+            /// </summary>
+            public const int Template = 3;
+        }
+
+        /// <summary>
+        /// Constants related to workflow categories.
+        /// </summary>
+        public static class WorkflowCategory
+        {
+            /// <summary>
+            /// Workflow category for workflows.
+            /// </summary>
+            public const int Workflow = 0;
+
+            /// <summary>
+            /// Workflow category for dialogs.
+            /// </summary>
+            public const int Dialog = 1;
+
+            /// <summary>
+            /// Workflow category for business rules.
+            /// </summary>
+            public const int BusinessRule = 2;
+
+            /// <summary>
+            /// Workflow category for actions.
+            /// </summary>
+            public const int Action = 3;
+
+            /// <summary>
+            /// Workflow category for business process flows.
+            /// </summary>
+            public const int BusinessProcessFlow = 4;
+
+            /// <summary>
+            /// Workflow category for modern flows.
+            /// </summary>
+            public const int ModernFlow = 5;
+
+            /// <summary>
+            /// Workflow category for desktop flows.
+            /// </summary>
+            public const int DesktopFlow = 6;
+
+            /// <summary>
+            /// Workflow category for AI flows.
+            /// </summary>
+            public const int AiFlow = 7;
+
+            /// <summary>
+            /// Workflow category for web client API flows.
+            /// </summary>
+            public const int WebClientApiFlow = 9000;
         }
 
         /// <summary>

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Constants.cs
@@ -107,9 +107,14 @@
                 public const string Name = "name";
 
                 /// <summary>
-                /// The name of the process.
+                /// The state code.
                 /// </summary>
                 public const string StateCode = "statecode";
+
+                /// <summary>
+                /// The status code.
+                /// </summary>
+                public const string StatusCode = "statuscode";
             }
         }
 

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -3,10 +3,11 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.ServiceModel;
     using Capgemini.PowerApps.PackageDeployerTemplate.Adapters;
-    using Microsoft.Crm.Sdk.Messages;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Sdk;
+    using Microsoft.Xrm.Sdk.Messages;
     using Microsoft.Xrm.Sdk.Query;
 
     /// <summary>
@@ -103,78 +104,65 @@
                 this.logger.LogInformation($"Activating processes as {user}.");
             }
 
-            var requests = this.GetSetStateRequests(processes, processesToDeactivate);
+            var requests = this.GetRequestByProcess(processes, processesToDeactivate);
 
             if (!requests.Any())
             {
                 return;
             }
 
-            this.ExecuteSetStateRequests(requests, user);
+            this.ExecuteUpdateRequests(requests, user);
         }
 
-        private void ExecuteSetStateRequests(IEnumerable<OrganizationRequest> requests, string user = null)
+        private void ExecuteUpdateRequests(IDictionary<Entity, UpdateRequest> requestsByProcess, string user = null)
         {
-            // Due to unpredictable process dependencies we should retry failed requests until there are zero successful responses.
-            var remainingRequests = new List<OrganizationRequest>(requests);
-            IEnumerable<ExecuteMultipleResponseItem> successfulResponses, failedResponses;
+            var nameMap = requestsByProcess.Keys
+                .ToDictionary(e => e.Id, e => e.GetAttributeValue<string>(Constants.Workflow.Fields.Name));
 
-            do
-            {
-                var timeout = 120 + (remainingRequests.Count * 10);
-                var executeMultipleResponses = this.crmSvc
-                    .ExecuteMultipleSolutionHistoryOperation(remainingRequests, user, timeout);
-
-                successfulResponses = executeMultipleResponses.Where(r => r.Fault == null);
-                failedResponses = executeMultipleResponses.Except(successfulResponses);
-                remainingRequests = failedResponses.Select(r => remainingRequests[r.RequestIndex]).ToList();
-            }
-            while (successfulResponses.Any() && remainingRequests.Any());
-
-            if (remainingRequests.Any())
-            {
-                foreach (var failedResponse in failedResponses)
+            this.crmSvc.ExecuteManySolutionHistoryOperation(
+                requestsByProcess.Values.Where(r => r != null),
+                user,
+                (r, ex) =>
                 {
-                    var failedRequest = (SetStateRequest)remainingRequests[failedResponse.RequestIndex];
-                    this.logger.LogError($"Failed to set state for process {failedRequest.EntityMoniker.Name} with the following error: {failedResponse.Fault.Message}.");
-                }
-            }
+                    this.logger.LogError($"Failed to update status of process {nameMap[((UpdateRequest)r).Target.Id]} with the following error: {((FaultException<OrganizationServiceFault>)ex).Detail.Message}");
+                });
         }
 
-        private List<OrganizationRequest> GetSetStateRequests(IEnumerable<Entity> processes, IEnumerable<string> processesToDeactivate)
+        private IDictionary<Entity, UpdateRequest> GetRequestByProcess(IEnumerable<Entity> processes, IEnumerable<string> processesToDeactivate)
         {
-            var requests = new List<OrganizationRequest>();
-
-            foreach (var deployedProcess in processes)
-            {
-                var stateCode = new OptionSetValue(Constants.Workflow.StateCodeActive);
-                var statusCode = new OptionSetValue(Constants.Workflow.StatusCodeActive);
-
-                if (processesToDeactivate != null && processesToDeactivate.Contains(deployedProcess[Constants.Workflow.Fields.Name]))
+            return processes.ToDictionary(
+                p => p,
+                p =>
                 {
-                    stateCode.Value = Constants.Workflow.StateCodeInactive;
-                    statusCode.Value = Constants.Workflow.StatusCodeInactive;
-                }
+                    var stateCode = new OptionSetValue(Constants.Workflow.StateCodeActive);
+                    var statusCode = new OptionSetValue(Constants.Workflow.StatusCodeActive);
 
-                if (stateCode.Value == deployedProcess.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value)
-                {
-                    this.logger.LogInformation($"Process {deployedProcess[Constants.Workflow.Fields.Name]} already has desired state. Skipping.");
-                    continue;
-                }
-
-                this.logger.LogInformation($"Setting process status for {deployedProcess[Constants.Workflow.Fields.Name]} with statecode {stateCode.Value} and statuscode {statusCode.Value}");
-
-                // SetStateRequest is supposedly deprecated but UpdateRequest doesn't work for deactivating active flows
-                requests.Add(
-                    new SetStateRequest
+                    if (processesToDeactivate != null && processesToDeactivate.Contains(p[Constants.Workflow.Fields.Name]))
                     {
-                        EntityMoniker = deployedProcess.ToEntityReference(),
-                        State = stateCode,
-                        Status = statusCode,
-                    });
-            }
+                        stateCode.Value = Constants.Workflow.StateCodeInactive;
+                        statusCode.Value = Constants.Workflow.StatusCodeInactive;
+                    }
 
-            return requests;
+                    if (stateCode.Value == p.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value)
+                    {
+                        this.logger.LogDebug($"Process {p[Constants.Workflow.Fields.Name]} already has desired state. Skipping.");
+                        return null;
+                    }
+
+                    this.logger.LogInformation($"Setting process status for {p[Constants.Workflow.Fields.Name]} with statecode {stateCode.Value} and statuscode {statusCode.Value}");
+
+                    return new UpdateRequest
+                    {
+                        Target = new Entity(Constants.Workflow.LogicalName, p.Id)
+                        {
+                            Attributes =
+                            {
+                                [Constants.Workflow.Fields.StateCode] = stateCode,
+                                [Constants.Workflow.Fields.StatusCode] = statusCode,
+                            },
+                        },
+                    };
+                });
         }
 
         private EntityCollection RetrieveProcesses(IEnumerable<string> names)

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -119,13 +119,43 @@
             var nameMap = requestsByProcess.Keys
                 .ToDictionary(e => e.Id, e => e.GetAttributeValue<string>(Constants.Workflow.Fields.Name));
 
-            this.crmSvc.ExecuteManySolutionHistoryOperation(
-                requestsByProcess.Values.Where(r => r != null),
-                user,
-                (r, ex) =>
-                {
-                    this.logger.LogError($"Failed to update status of process {nameMap[((UpdateRequest)r).Target.Id]} with the following error: {((FaultException<OrganizationServiceFault>)ex).Detail.Message}");
-                });
+            var remainingRequests = requestsByProcess.Values.Where(r => r != null);
+            if (!remainingRequests.Any())
+            {
+                return;
+            }
+
+            this.logger.LogInformation($"Updating the states of {remainingRequests.Count()} processes.");
+
+            var iteration = 1;
+            var iterationSuccessfulRequestCount = 0;
+            var errorMessages = new List<string>();
+            do
+            {
+                errorMessages = new List<string>();
+                var responses = this.crmSvc.ExecuteManySolutionHistoryOperation(
+                    remainingRequests,
+                    user,
+                    (r, ex) =>
+                    {
+                        errorMessages.Add($"Failed to update status of process {nameMap[((UpdateRequest)r).Target.Id]} with the following error: {((FaultException<OrganizationServiceFault>)ex).Detail.Message}");
+                    });
+
+                remainingRequests = responses
+                    .Where(kvp => kvp.Value is null)
+                    .Select(kvp => kvp.Key)
+                    .Cast<UpdateRequest>();
+
+                iterationSuccessfulRequestCount = responses.Values.Where(v => v != null).Count();
+                this.logger.LogInformation($"Successfully updated the state of {iterationSuccessfulRequestCount} processes in iteration {iteration}.");
+                iteration++;
+            }
+            while (remainingRequests.Any() && iterationSuccessfulRequestCount > 0);
+
+            foreach (var errorMessage in errorMessages)
+            {
+                this.logger.LogError(errorMessage);
+            }
         }
 
         private IDictionary<Entity, UpdateRequest> GetRequestByProcess(IEnumerable<Entity> processes, IEnumerable<string> processesToDeactivate)
@@ -145,11 +175,11 @@
 
                     if (stateCode.Value == p.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value)
                     {
-                        this.logger.LogDebug($"Process {p[Constants.Workflow.Fields.Name]} already has desired state. Skipping.");
+                        this.logger.LogInformation($"Process {p[Constants.Workflow.Fields.Name]} will be skipped. Already has desired state.");
                         return null;
                     }
 
-                    this.logger.LogInformation($"Setting process status for {p[Constants.Workflow.Fields.Name]} with statecode {stateCode.Value} and statuscode {statusCode.Value}");
+                    this.logger.LogInformation($"Process {p[Constants.Workflow.Fields.Name]} will be {(stateCode.Value == Constants.Workflow.StateCodeActive ? "activated" : "deactivated")}.");
 
                     return new UpdateRequest
                     {

--- a/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
+++ b/src/Capgemini.PowerApps.PackageDeployerTemplate/Services/ProcessDeploymentService.cs
@@ -39,6 +39,19 @@
         {
             this.logger.LogInformation("Setting process states in solution(s).");
 
+            var categoryOrder = new[]
+            {
+                Constants.WorkflowCategory.BusinessRule,
+                Constants.WorkflowCategory.Action,
+                Constants.WorkflowCategory.Workflow,
+                Constants.WorkflowCategory.BusinessProcessFlow,
+                Constants.WorkflowCategory.ModernFlow,
+                Constants.WorkflowCategory.Dialog,
+                Constants.WorkflowCategory.DesktopFlow,
+                Constants.WorkflowCategory.AiFlow,
+                Constants.WorkflowCategory.WebClientApiFlow,
+            };
+
             if (solutions == null || !solutions.Any())
             {
                 this.logger.LogInformation("No solutions were provided to activate processes for.");
@@ -49,9 +62,26 @@
                 solutions,
                 Constants.SolutionComponent.ComponentTypeWorkflow,
                 Constants.Workflow.LogicalName,
-                new ColumnSet(Constants.Workflow.Fields.Name, Constants.Workflow.Fields.StateCode)).Entities;
+                new ColumnSet(
+                    Constants.Workflow.Fields.Name,
+                    Constants.Workflow.Fields.Category,
+                    Constants.Workflow.Fields.StateCode)).Entities;
 
-            this.SetStates(deployedProcesses, componentsToDeactivate, user);
+            foreach (var category in categoryOrder)
+            {
+                this.logger.LogInformation($"Checking for deployed processes in solution(s) with category {category}.");
+
+                var processesInCategory = deployedProcesses.Where(p => p.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.Category).Value == category);
+                if (!processesInCategory.Any())
+                {
+                    this.logger.LogInformation($"No deployed processes were found in solution(s) with category {category}.");
+                    continue;
+                }
+
+                this.logger.LogInformation($"Found {processesInCategory.Count()} deployed processes in solution(s) with category {category}.");
+
+                this.SetStates(processesInCategory, componentsToDeactivate, user);
+            }
         }
 
         /// <summary>
@@ -202,7 +232,7 @@
                 ColumnSet = new ColumnSet(Constants.Workflow.Fields.Name, Constants.Workflow.Fields.StateCode, Constants.Workflow.Fields.Type),
             };
             query.Criteria.AddCondition(Constants.Workflow.Fields.Name, ConditionOperator.In, names.ToArray<object>());
-            query.Criteria.AddCondition(Constants.Workflow.Fields.Type, ConditionOperator.Equal, Constants.Workflow.TypeDefinition);
+            query.Criteria.AddCondition(Constants.Workflow.Fields.Type, ConditionOperator.Equal, Constants.WorkflowType.Definition);
 
             var results = this.crmSvc.RetrieveMultiple(query);
             this.logger.LogInformation($"Found {results.Entities.Count} processes matching the {names.Count()} provided names.");

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageTemplateBaseTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.IntegrationTests/PackageTemplateBaseTests.cs
@@ -81,7 +81,7 @@
         {
             var workflowQuery = new QueryByAttribute(Constants.Workflow.LogicalName);
             workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Name, "When a contact is created do nothing");
-            workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Type, Constants.Workflow.TypeDefinition);
+            workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Type, Constants.WorkflowType.Definition);
             workflowQuery.ColumnSet = new ColumnSet("statecode");
 
             var workflow = this.fixture.ServiceClient.RetrieveMultiple(workflowQuery).Entities.FirstOrDefault();
@@ -94,7 +94,7 @@
         {
             var workflowQuery = new QueryByAttribute(Constants.Workflow.LogicalName);
             workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Name, "When an account is created do nothing");
-            workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Type, Constants.Workflow.TypeDefinition);
+            workflowQuery.AddAttributeValue(Constants.Workflow.Fields.Type, Constants.WorkflowType.Definition);
             workflowQuery.ColumnSet = new ColumnSet("statecode");
 
             var workflow = this.fixture.ServiceClient.RetrieveMultiple(workflowQuery).Entities.FirstOrDefault();

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ConnectionReferenceDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ConnectionReferenceDeploymentServiceTests.cs
@@ -79,7 +79,7 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.Services
 
             this.connectionReferenceSvc.ConnectConnectionReferences(connectionMap, connectionOwner);
 
-            this.crmSvc.Verify(svc => svc.Execute<ExecuteMultipleResponse>(It.IsAny<OrganizationRequest>(), connectionOwner, true));
+            this.crmSvc.Verify(svc => svc.Execute<ExecuteMultipleResponse>(It.IsAny<OrganizationRequest>(), connectionOwner, It.IsAny<bool>(), It.IsAny<bool>()));
         }
 
         [Fact]
@@ -119,8 +119,12 @@ namespace Capgemini.PowerApps.PackageDeployerTemplate.UnitTests.Services
 
         private void MockUpdateConnectionReferencesResponse(ExecuteMultipleResponse response)
         {
-            this.crmSvc.Setup(svc => svc.Execute(It.IsAny<ExecuteMultipleRequest>())).Returns(response);
-            this.crmSvc.Setup(svc => svc.Execute<ExecuteMultipleResponse>(It.IsAny<ExecuteMultipleRequest>(), It.IsAny<string>(), true)).Returns(response);
+            this.crmSvc
+                .Setup(svc => svc.Execute(It.IsAny<ExecuteMultipleRequest>()))
+                .Returns(response);
+            this.crmSvc
+                .Setup(svc => svc.Execute<ExecuteMultipleResponse>(It.IsAny<ExecuteMultipleRequest>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(response);
         }
 
         private EntityCollection MockConnectionReferencesForConnectionMap(Dictionary<string, string> connectionMap)

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
@@ -4,10 +4,10 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.ServiceModel;
     using Capgemini.PowerApps.PackageDeployerTemplate.Adapters;
     using Capgemini.PowerApps.PackageDeployerTemplate.Services;
     using FluentAssertions;
-    using Microsoft.Crm.Sdk.Messages;
     using Microsoft.Extensions.Logging;
     using Microsoft.Xrm.Sdk;
     using Microsoft.Xrm.Sdk.Messages;
@@ -61,18 +61,18 @@
         {
             var solutionProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeActive) };
             this.MockBySolutionProcesses(solutionProcesses);
-            this.MockExecuteMultipleSolutionHistoryOperationResponse(
+            this.MockExecuteManySolutionHistoryOperationResponse(
                 null,
-                svc => svc.ExecuteMultipleSolutionHistoryOperation(
+                svc => svc.ExecuteManySolutionHistoryOperation(
                 It.Is<IEnumerable<OrganizationRequest>>(
-                    reqs => reqs.Cast<SetStateRequest>().Any(
+                    reqs => reqs.Cast<UpdateRequest>().Any(
                         req =>
-                        req.EntityMoniker.LogicalName == Constants.Workflow.LogicalName &&
-                        req.EntityMoniker.Id == solutionProcesses.First().Id &&
-                        req.State.Value == Constants.Workflow.StateCodeInactive &&
-                        req.Status.Value == Constants.Workflow.StatusCodeInactive)),
+                        req.Target.LogicalName == Constants.Workflow.LogicalName &&
+                        req.Target.Id == solutionProcesses.First().Id &&
+                        req.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value == Constants.Workflow.StateCodeInactive &&
+                        req.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StatusCode).Value == Constants.Workflow.StatusCodeInactive)),
                 It.IsAny<string>(),
-                It.IsAny<int?>()),
+                It.IsAny<Action<OrganizationRequest, Exception>>()),
                 true);
 
             this.processDeploymentSvc.SetStatesBySolution(
@@ -94,12 +94,12 @@
                 GetProcess(Constants.Workflow.StateCodeInactive),
             };
             this.MockBySolutionProcesses(solutionProcesses);
-            this.MockExecuteMultipleSolutionHistoryOperationResponse(
+            this.MockExecuteManySolutionHistoryOperationResponse(
                 null,
-                svc => svc.ExecuteMultipleSolutionHistoryOperation(
+                svc => svc.ExecuteManySolutionHistoryOperation(
                     It.IsAny<IEnumerable<OrganizationRequest>>(),
                     userToImpersonate,
-                    It.IsAny<int?>()));
+                    It.IsAny<Action<OrganizationRequest, Exception>>()));
 
             this.processDeploymentSvc.SetStatesBySolution(
                 Solutions, user: userToImpersonate);
@@ -162,7 +162,7 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
-            this.MockExecuteMultipleSolutionHistoryOperationResponse();
+            this.MockExecuteManySolutionHistoryOperationResponse();
 
             this.processDeploymentSvc.SetStates(new List<string>
             {
@@ -177,18 +177,18 @@
         {
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeActive) };
             this.MockSetStatesProcesses(foundProcesses);
-            this.MockExecuteMultipleSolutionHistoryOperationResponse(
+            this.MockExecuteManySolutionHistoryOperationResponse(
                 null,
-                svc => svc.ExecuteMultipleSolutionHistoryOperation(
+                svc => svc.ExecuteManySolutionHistoryOperation(
                 It.Is<IEnumerable<OrganizationRequest>>(
-                    reqs => reqs.Cast<SetStateRequest>().Any(
+                    reqs => reqs.Cast<UpdateRequest>().Any(
                         req =>
-                        req.EntityMoniker.LogicalName == Constants.Workflow.LogicalName &&
-                        req.EntityMoniker.Id == foundProcesses.First().Id &&
-                        req.State.Value == Constants.Workflow.StateCodeInactive &&
-                        req.Status.Value == Constants.Workflow.StatusCodeInactive)),
+                        req.Target.LogicalName == Constants.Workflow.LogicalName &&
+                        req.Target.Id == foundProcesses.First().Id &&
+                        req.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StateCode).Value == Constants.Workflow.StateCodeInactive &&
+                        req.Target.GetAttributeValue<OptionSetValue>(Constants.Workflow.Fields.StatusCode).Value == Constants.Workflow.StatusCodeInactive)),
                 It.IsAny<string>(),
-                It.IsAny<int?>()),
+                It.IsAny<Action<OrganizationRequest, Exception>>()),
                 true);
 
             this.processDeploymentSvc.SetStates(Enumerable.Empty<string>(), new List<string>
@@ -205,12 +205,12 @@
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
             var userToImpersonate = "licenseduser@domaincom";
-            this.MockExecuteMultipleSolutionHistoryOperationResponse(
+            this.MockExecuteManySolutionHistoryOperationResponse(
                 null,
-                svc => svc.ExecuteMultipleSolutionHistoryOperation(
+                svc => svc.ExecuteManySolutionHistoryOperation(
                 It.IsAny<IEnumerable<OrganizationRequest>>(),
                 userToImpersonate,
-                It.IsAny<int?>()),
+                It.IsAny<Action<OrganizationRequest, Exception>>()),
                 true);
 
             this.processDeploymentSvc.SetStates(
@@ -230,16 +230,16 @@
             var foundProcesses = new List<Entity> { GetProcess(Constants.Workflow.StateCodeInactive) };
             this.MockSetStatesProcesses(foundProcesses);
             var fault = new OrganizationServiceFault { Message = "Some error." };
-            var response = new ExecuteMultipleResponse
-            {
-                Results = new ParameterCollection
-                {
-                    { "Responses", new ExecuteMultipleResponseItemCollection() },
-                    { "IsFaulted", true },
-                },
-            };
-            response.Responses.Add(new ExecuteMultipleResponseItem { Fault = fault });
-            this.MockExecuteMultipleSolutionHistoryOperationResponse(response.Responses);
+            this.crmServiceAdapterMock
+                .Setup(svc => svc.ExecuteManySolutionHistoryOperation(
+                    It.IsAny<IEnumerable<OrganizationRequest>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Action<OrganizationRequest, Exception>>()))
+                .Callback<IEnumerable<OrganizationRequest>, string, Action<OrganizationRequest, Exception>>(
+                    (requests, username, onError) =>
+                    {
+                        onError(requests.First(), new FaultException<OrganizationServiceFault>(fault));
+                    });
 
             this.processDeploymentSvc.SetStates(
                 new List<string>
@@ -292,28 +292,22 @@
                 .Returns(new EntityCollection(processes));
         }
 
-        private void MockExecuteMultipleSolutionHistoryOperationResponse(
-            IEnumerable<ExecuteMultipleResponseItem> responses = null,
-            Expression<Func<ICrmServiceAdapter, IEnumerable<ExecuteMultipleResponseItem>>> expression = null,
+        private void MockExecuteManySolutionHistoryOperationResponse(
+            IEnumerable<OrganizationResponse> responses = null,
+            Expression<Func<ICrmServiceAdapter, IEnumerable<OrganizationResponse>>> expression = null,
             bool verifiable = false)
         {
             if (expression == null)
             {
-                expression = svc => svc.ExecuteMultipleSolutionHistoryOperation(
+                expression = svc => svc.ExecuteManySolutionHistoryOperation(
                     It.IsAny<IEnumerable<OrganizationRequest>>(),
                     It.IsAny<string>(),
-                    It.IsAny<int?>());
+                    It.IsAny<Action<OrganizationRequest, Exception>>());
             }
 
             if (responses == null)
             {
-                var executeMultipleResponse = new ExecuteMultipleResponse();
-                executeMultipleResponse.Results["Responses"] = new ExecuteMultipleResponseItemCollection()
-                {
-                    new ExecuteMultipleResponseItem() { RequestIndex = 0 },
-                    new ExecuteMultipleResponseItem() { RequestIndex = 1 },
-                };
-                responses = executeMultipleResponse.Responses;
+                responses = Enumerable.Empty<OrganizationResponse>();
             }
 
             var returnResult = this.crmServiceAdapterMock

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
@@ -268,6 +268,9 @@
                     {
                         Constants.Workflow.Fields.StateCode, new OptionSetValue(stateCode)
                     },
+                    {
+                        Constants.Workflow.Fields.Category, new OptionSetValue(Constants.WorkflowCategory.Workflow)
+                    },
                 },
             };
         }

--- a/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
+++ b/tests/Capgemini.PowerApps.PackageDeployerTemplate.UnitTests/Services/ProcessDeploymentServiceTests.cs
@@ -238,8 +238,13 @@
                 .Callback<IEnumerable<OrganizationRequest>, string, Action<OrganizationRequest, Exception>>(
                     (requests, username, onError) =>
                     {
-                        onError(requests.First(), new FaultException<OrganizationServiceFault>(fault));
-                    });
+                        foreach (var request in requests)
+                        {
+                            onError(request, new FaultException<OrganizationServiceFault>(fault));
+                        }
+                    })
+                .Returns<IEnumerable<OrganizationRequest>, string, Action<OrganizationRequest, Exception>>(
+                    (requests, username, onError) => requests.ToDictionary(r => r, r => (OrganizationResponse)null));
 
             this.processDeploymentSvc.SetStates(
                 new List<string>
@@ -293,8 +298,8 @@
         }
 
         private void MockExecuteManySolutionHistoryOperationResponse(
-            IEnumerable<OrganizationResponse> responses = null,
-            Expression<Func<ICrmServiceAdapter, IEnumerable<OrganizationResponse>>> expression = null,
+            IDictionary<OrganizationRequest, OrganizationResponse> response = null,
+            Expression<Func<ICrmServiceAdapter, IDictionary<OrganizationRequest, OrganizationResponse>>> expression = null,
             bool verifiable = false)
         {
             if (expression == null)
@@ -305,14 +310,14 @@
                     It.IsAny<Action<OrganizationRequest, Exception>>());
             }
 
-            if (responses == null)
+            if (response == null)
             {
-                responses = Enumerable.Empty<OrganizationResponse>();
+                response = new Dictionary<OrganizationRequest, OrganizationResponse>();
             }
 
             var returnResult = this.crmServiceAdapterMock
                 .Setup(expression)
-                .Returns(responses);
+                .Returns(response);
 
             if (verifiable)
             {


### PR DESCRIPTION
## Purpose

There have been issues with flows failing to be activated with warnings suggesting that the actions that they're dependent on are not active.

This problem did not exist prior to switching to `ExecuteMultipleRequest`s for updating process statuses.

## Approach

Reverts back to individual `UpdateRequest`s. This should be more performant now that we check the statuses of processes before making a request to activate or deactivate them.

## TODOs
- [x] Automated test coverage for new code
- [x] Documentation updated (if required)
- [x] Build and tests successful
